### PR TITLE
fix(docs): scope cla permissions to job level

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,10 @@ jobs:
   cla:
     # PR 时自动执行，或者评论 /check-cla 时执行
     if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_call' || (github.event.issue.pull_request && contains(github.event.comment.body, '/check-cla'))
+    permissions:
+      checks: write
+      pull-requests: write
+      contents: read
     uses: open-vela/public-actions/.github/workflows/cla.yml@dev
     secrets: inherit
 


### PR DESCRIPTION
## Problem

The `cla.yml` reusable workflow requires `checks: write` and `pull-requests: write`, but the `docs` job doesn't need these elevated permissions. Previously these were set at the workflow top-level, granting all jobs more permissions than necessary.

## Fix

Move `checks: write` and `pull-requests: write` from the top-level permissions block to the `cla` job level, keeping the top-level permissions minimal.

Top-level permissions (applies to `docs` job):

```yaml
permissions:
  contents: read
  pull-requests: read
  issues: write
  statuses: write
```

`cla` job permissions:

```yaml
permissions:
  checks: write
  pull-requests: write
  contents: read
```