### PR TITLE
fix(docs): add statuses:write to cla job permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,9 +25,10 @@ jobs:
     # PR 时自动执行，或者评论 /check-cla 时执行
     if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_call' || (github.event.issue.pull_request && contains(github.event.comment.body, '/check-cla'))
     permissions:
+      contents: read
       checks: write
       pull-requests: write
-      contents: read
+      statuses: write
     uses: open-vela/public-actions/.github/workflows/cla.yml@dev
     secrets: inherit
 


### PR DESCRIPTION
## Problem

The `cla` job in `docs.yml` declares job-level `permissions`, which completely overrides the top-level permissions. The previous PR missed `statuses: write`, causing CI to fail:

```
Error calling workflow 'open-vela/public-actions/.github/workflows/cla.yml@dev'.
The workflow is requesting 'statuses: write', but is only allowed 'statuses: none'.
```

## Fix

Add `statuses: write` to the `cla` job permissions block:

```yaml
cla:
  permissions:
    contents: read
    checks: write
    pull-requests: write
    statuses: write
```