### PR TITLE
fix(docs): move cla permissions to top level

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,8 @@ on:
 # Restrict permissions to minimum required
 permissions:
   contents: read
-  pull-requests: read
+  checks: write
+  pull-requests: write
   issues: write
   statuses: write
 
@@ -24,11 +25,6 @@ jobs:
   cla:
     # PR 时自动执行，或者评论 /check-cla 时执行
     if: github.event_name == 'pull_request_target' || github.event_name == 'workflow_call' || (github.event.issue.pull_request && contains(github.event.comment.body, '/check-cla'))
-    permissions:
-      contents: read
-      checks: write
-      pull-requests: write
-      statuses: write
     uses: open-vela/public-actions/.github/workflows/cla.yml@dev
     secrets: inherit
 


### PR DESCRIPTION
## Problem

Job-level `permissions` in a reusable workflow do not work correctly when the workflow is called via `workflow_call` from another repo. The `cla` job's job-level permissions were being ignored, causing:

```
Error calling workflow 'open-vela/public-actions/.github/workflows/cla.yml@dev'.
The workflow is requesting 'statuses: write', but is only allowed 'statuses: none'.
```

## Fix

Remove job-level permissions from the `cla` job and declare all required permissions at the top level:

```yaml
permissions:
  contents: read
  checks: write
  pull-requests: write
  issues: write
  statuses: write
```

This ensures `cla.yml` inherits the correct permissions when `docs.yml` is called as a reusable workflow from other repos like `open-vela/docs`.