### PR TITLE
fix(cla): improve error handling for API failures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -45,12 +45,22 @@ jobs:
 
       - name: Check CLA for All Commits
         id: cla
+        continue-on-error: true
         timeout-minutes: 5
         run: |
+          set +e
           COMMITS_URL="${{ steps.pr-info.outputs.commits_url }}"
           
           ALL_EMAILS=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             "$COMMITS_URL" | jq -r '.[].commit.author.email' | sort | uniq)
+          CURL_EXIT=$?
+          
+          if [ $CURL_EXIT -ne 0 ] || [ -z "$ALL_EMAILS" ]; then
+            echo "⚠️ Failed to fetch commit emails (exit code: $CURL_EXIT)"
+            echo "error=api_error" >> $GITHUB_OUTPUT
+            echo "signed=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           
           VALID_EMAILS=$(echo "$ALL_EMAILS" | grep -v "noreply.github.com" | grep -v "^$" | grep -v "null")
           
@@ -150,6 +160,9 @@ jobs:
             if (error === 'no_email') {
               state = 'error';
               description = 'Cannot determine emails from commits';
+            } else if (error === 'api_error') {
+              state = 'error';
+              description = 'CLA check failed: unable to fetch commit data or reach CLA API';
             } else if (signed) {
               const emailCount = emails.split(',').length;
               state = 'success';
@@ -257,8 +270,4 @@ jobs:
         run: |
           echo "❌ CLA signature required"
           echo "Unsigned contributors: ${{ steps.cla.outputs.unsigned }}"
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            echo "This workflow fails to prevent PR merge until CLA is signed"
-          else
-            echo "This workflow fails to show that CLA check did not pass"
-          fi
+          exit 1


### PR DESCRIPTION
## Problem

When the CLA API (`vela-website.hybrid.xiaomi.com`) is unreachable from GitHub Actions runners, the "Check CLA for All Commits" step crashes due to `bash -e` mode. This prevents the subsequent "Set CLA Status" step from running, so no status or comment is posted back to the PR.

## Fix

- Add `set +e` at the beginning of the CLA check script to prevent early exit on command failures
- Add `continue-on-error: true` to ensure subsequent steps (status reporting, PR comments) always execute
- Validate `curl` exit code before processing email data
- Handle `api_error` case in the status reporting step with a descriptive message

This ensures that even when the CLA API is down, the workflow will still post a status check and comment on the PR explaining the failure.