### PR TITLE
fix(cla): detect /check-cla trigger via workflow_call

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -28,32 +28,48 @@ jobs:
         with:
           script: |
             let pr;
-            if (context.eventName === 'pull_request' || context.eventName === 'pull_request_target') {
-              pr = context.payload.pull_request;
-            } else if (context.eventName === 'workflow_call') {
-              // When called as reusable workflow, PR info is in the caller's context
-              pr = context.payload.pull_request;
-              if (!pr) {
-                core.setOutput('author', 'unknown');
-                core.setOutput('head_sha', context.sha);
-                core.setOutput('commits_url', '');
-                core.setOutput('pr_number', '0');
-                return;
-              }
-            } else {
-              // issue_comment event
+            let triggerType = 'pr'; // 'pr' or 'comment'
+            
+            if (context.eventName === 'issue_comment') {
+              // Direct issue_comment event (not via workflow_call)
+              triggerType = 'comment';
               const { data } = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: context.issue.number
               });
               pr = data;
+            } else if (context.eventName === 'workflow_call') {
+              // Called as reusable workflow from docs.yml
+              // Check if the original trigger was an issue_comment (/check-cla)
+              if (context.payload.comment && context.payload.issue) {
+                triggerType = 'comment';
+                const { data } = await github.rest.pulls.get({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.payload.issue.number
+                });
+                pr = data;
+              } else if (context.payload.pull_request) {
+                pr = context.payload.pull_request;
+              } else {
+                core.setOutput('author', 'unknown');
+                core.setOutput('head_sha', context.sha);
+                core.setOutput('commits_url', '');
+                core.setOutput('pr_number', '0');
+                core.setOutput('trigger_type', 'pr');
+                return;
+              }
+            } else {
+              // pull_request or pull_request_target event
+              pr = context.payload.pull_request;
             }
             
             core.setOutput('author', pr.user.login);
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('commits_url', pr.commits_url);
             core.setOutput('pr_number', pr.number.toString());
+            core.setOutput('trigger_type', triggerType);
 
       - name: Check CLA for All Commits
         id: cla
@@ -199,9 +215,11 @@ jobs:
             
             console.log(`✅ Set CLA status: ${state} - ${description}`);
             
-            // 如果需要签署 CLA 且不是评论触发，添加评论
             const prNumber = parseInt('${{ steps.pr-info.outputs.pr_number }}') || context.issue?.number;
-            if (!signed && !error && prNumber && (context.eventName === 'pull_request' || context.eventName === 'pull_request_target' || context.eventName === 'workflow_call')) {
+            const triggerType = '${{ steps.pr-info.outputs.trigger_type }}';
+            
+            // Post comment when CLA not signed and triggered by PR event
+            if (!signed && !error && prNumber && triggerType === 'pr') {
               const emailList = emails.split(',').map(e => e.trim()).filter(e => e);
               const unsignedList = unsigned ? unsigned.split(',').map(e => e.trim()).filter(e => e) : [];
               
@@ -228,8 +246,8 @@ jobs:
               });
             }
             
-            // 如果是评论触发且成功，添加成功评论
-            if (signed && context.eventName === 'issue_comment') {
+            // Post success comment when triggered by /check-cla comment
+            if (signed && triggerType === 'comment' && prNumber) {
               const emailList = emails.split(',').map(e => e.trim()).filter(e => e);
               
               const body = `## ✅ CLA Verification Complete
@@ -250,8 +268,8 @@ jobs:
               });
             }
             
-            // 如果是评论触发但 CLA 仍未签署，添加提醒评论
-            if (!signed && !error && context.eventName === 'issue_comment') {
+            // Post reminder when triggered by /check-cla but CLA still not signed
+            if (!signed && !error && triggerType === 'comment' && prNumber) {
               const emailList = emails.split(',').map(e => e.trim()).filter(e => e);
               const unsignedList = unsigned ? unsigned.split(',').map(e => e.trim()).filter(e => e) : [];
               


### PR DESCRIPTION
When cla.yml is called via workflow_call from docs.yml, `context.eventName` is always `workflow_call` even if the original trigger was `/check-cla` comment. This causes all `issue_comment` condition checks to fail, so no comments are posted back.\n\nFix: Add `trigger_type` output that inspects `context.payload.comment` to detect `/check-cla` triggers. Use `triggerType` instead of `context.eventName` for comment posting logic.