### PR TITLE
test: docs.yml pull-requests read permission

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ on:
 permissions:
   contents: read
   checks: write
-  pull-requests: write
+  pull-requests: read
   issues: write
   statuses: write
 


### PR DESCRIPTION
Test: change `pull-requests` permission from `write` to `read` in docs.yml to verify if CLA comment posting still works via reusable workflow.