### PR TITLE
fix(ci): apply manifest PR before repo sync

### DIFF
--- a/.github/workflows/ci-real.yml
+++ b/.github/workflows/ci-real.yml
@@ -183,6 +183,21 @@ jobs:
         ~/bin/repo init -u https://github.com/open-vela/manifests -b "$PR_BASE_REF" -m openvela.xml --group=default,platform-linux --depth=1 --git-lfs
         echo "REPO_INIT=true" >> $GITHUB_ENV
 
+    - name: Apply manifest PR before sync
+      if: ${{ github.event_name == 'pull_request_target' && github.repository == 'open-vela/manifests' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        git config --global user.email "openvela-robot@xiaomi.com"
+        git config --global user.name "openvela-robot"
+        cd .repo/manifests
+        git fetch origin pull/$PR_NUMBER/head:pr-branch
+        git cherry-pick $(git rev-list --reverse HEAD..$PR_HEAD_SHA) || true
+        cd -
+
     - name: Repo Sync
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

When a PR targets the `open-vela/manifests` repo and adds new projects (e.g. `build`), the CI setup job generates a snapshot based on the old manifest before the PR changes are applied. This means new repos are missing from the snapshot, causing build failures in ci-tasks.

## Fix

Add an `Apply manifest PR before sync` step in the setup job that cherry-picks the manifest PR changes before running `repo sync`. This step only runs when the PR is from `open-vela/manifests`.

## Flow change

Before:
```
Repo Init → Repo Sync (old manifest) → Generate Snapshot
```

After:
```
Repo Init → Cherry-pick manifest PR → Repo Sync (updated manifest) → Generate Snapshot
```