### PR TITLE
fix(ci): apply manifest PR before repo sync (trunk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,21 @@ jobs:
         ~/bin/repo init -u https://github.com/open-vela/manifests -b "$PR_BASE_REF" -m openvela.xml --group=default,platform-linux --depth=1 --git-lfs
         echo "REPO_INIT=true" >> $GITHUB_ENV
 
+    - name: Apply manifest PR before sync
+      if: ${{ github.event_name == 'pull_request_target' && github.repository == 'open-vela/manifests' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        git config --global user.email "openvela-robot@xiaomi.com"
+        git config --global user.name "openvela-robot"
+        cd .repo/manifests
+        git fetch origin pull/$PR_NUMBER/head:pr-branch
+        git cherry-pick $(git rev-list --reverse HEAD..$PR_HEAD_SHA) || true
+        cd -
+
     - name: Repo Sync
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Same fix as #55 but for the trunk branch (ci.yml instead of ci-real.yml).

When a PR targets `open-vela/manifests` and adds new projects (e.g. `build`), the CI setup job needs to cherry-pick the manifest changes before `repo sync`. Otherwise the snapshot won't include new repos and the build fails.

This is needed because manifests CI references `public-actions/.github/workflows/ci.yml@trunk`.