### PR TITLE
fix(ci): disable kcore0 build task (trunk)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
           - group: ubuntu22-01
             tasks: [goldfish-arm64-v8a-ap@cmake, goldfish-armeabi-v7a-ap@cmake, goldfish-x86_64-ap@cmake]  # 第一组任务
           - group: ubuntu22-02
-            tasks: [./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_core0@cmake, ./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core0@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core1@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core2@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core3@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core4@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core5@cmake, ./vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake, ./vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0@cmake]  # 第二组任务
+            tasks: [./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_core0@cmake, ./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core0@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core1@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core2@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core3@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core4@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core5@cmake, ./vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake]  # 第二组任务（kcore0 disabled: multiple definition of userspace）
       fail-fast: false
     outputs:
       status: ${{ steps.check.outputs.status }}


### PR DESCRIPTION
Disable `kcore0` build task in trunk CI.

`kcore0` has a `multiple definition of 'userspace'` linker error caused by both `fc7300_userspace.c` and `arm_userspace.c` defining the `userspace` symbol. This is a vendor code / CMake configuration issue, not a CI issue.

Disable it until the vendor fixes the CMake configuration.