### PR TITLE
ci: reorganize matrix by vendor and add qemu/kcore0 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,17 +224,19 @@ jobs:
       DOCKER_BUILDKIT: 1
     strategy:
       matrix:
-        group: [ubuntu22-01, ubuntu22-02]  # 定义组
+        group: [goldfish, qemu, sil, aurix, flagchip]  # grouped by vendor / platform
         include:
-          - group: ubuntu22-01
-            tasks: [goldfish-arm64-v8a-ap@cmake, goldfish-armeabi-v7a-ap@cmake, goldfish-x86_64-ap@cmake]  # 第一组任务
-          - group: ubuntu22-02
-            tasks: [./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_core0@cmake, ./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core0@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core1@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core2@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core3@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core4@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core5@cmake, ./vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake]  # 第二组任务（kcore0 disabled: multiple definition of userspace）
+          - group: goldfish
+            tasks: [goldfish-arm64-v8a-ap@cmake, goldfish-armeabi-v7a-ap@cmake, goldfish-x86_64-ap@cmake]
+          - group: qemu
+            tasks: [qemu-arm64-v8a-ap@cmake, qemu-arm64-v8a-server@cmake, qemu-armeabi-v7a-ap@cmake, qemu-armeabi-v7a-bl@cmake, qemu-armeabi-v7a-server@cmake, qemu-armeabi-v7a-tee@cmake, qemu-armeabi-v8m-ap@cmake]
+          - group: sil
+            tasks: [./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_core0@cmake, ./vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_bl@cmake]
+          - group: aurix
+            tasks: [./vendor/infineon/boards/aurix/tc4d9_evb/configs/bl@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core0@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core1@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core2@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core3@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core4@cmake, ./vendor/infineon/boards/aurix/tc4d9_evb/configs/core5@cmake]
+          - group: flagchip
+            tasks: [./vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake, ./vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0@cmake]
       fail-fast: false
-    outputs:
-      status: ${{ steps.check.outputs.status }}
-      DEPENDS_ON: ${{ needs.setup.outputs.DEPENDS_ON }}
-      CURRENT_ACTION_URL: ${{ needs.setup.outputs.CURRENT_ACTION_URL }}
     steps:
       - name: Download Snapshot and PR Info
         uses: actions/download-artifact@v4
@@ -533,15 +535,12 @@ jobs:
           path: |
             ${{ matrix.group }}
 
-      - name: Check status
-        id: check
-        if: always()
-        run: |
-          echo "status=${{ job.status }}" >> $GITHUB_OUTPUT
-
-  # 后置处理作业，用于更新依赖PR状态
+  # Post-processing job to update dependent PR statuses.
+  # Uses needs.ci-tasks.result to aggregate results across all matrix groups:
+  # it is "success" only when every matrix instance succeeds; any failure or
+  # cancellation in any group will make it "failure".
   post-processing:
-    needs: ci-tasks
+    needs: [setup, ci-tasks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -555,9 +554,9 @@ jobs:
 
       - name: Post Processing
         env:
-          CI_TASKS_STATUS: ${{ needs.ci-tasks.outputs.status }}
-          DEPENDS_ON: ${{ needs.ci-tasks.outputs.DEPENDS_ON }}
-          CURRENT_ACTION_URL: ${{ needs.ci-tasks.outputs.CURRENT_ACTION_URL }}
+          CI_TASKS_STATUS: ${{ needs.ci-tasks.result }}
+          DEPENDS_ON: ${{ needs.setup.outputs.DEPENDS_ON }}
+          CURRENT_ACTION_URL: ${{ needs.setup.outputs.CURRENT_ACTION_URL }}
           CI_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           echo "Job status: $CI_TASKS_STATUS"


### PR DESCRIPTION
## Summary

Reorganize the `ci-tasks` matrix from opaque `ubuntu22-0x` groups into vendor-based groups, add the missing `qemu/kcore0` builds, and fix a latent bug in how overall CI status is reported to dependent PRs.

## Matrix reorganization

| group | count | notes |
|---|---|---|
| `goldfish` | 3 | Android goldfish emulator (unchanged) |
| `qemu` | 7 | **new** — qemu vela configs |
| `sil` | 2 | openvela SIL (moved out of old `ubuntu22-02`) |
| `aurix` | 7 | Infineon AURIX TC4D9 (moved out of old `ubuntu22-02`) |
| `flagchip` | 2 | Flagchip FC7300, includes re-enabled `kcore0@cmake` |

Benefits:
- 5 parallel runners instead of 2, shorter wall-clock time.
- Failures are easier to triage — the failing group name names the vendor.
- Build artifacts (`Build_Package_goldfish`, `Build_Package_qemu`, …) are now semantically named.

## Added build tasks

All with `--cmake`:

- `vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0`
- `vendor/openvela/boards/vela/configs/qemu-arm64-v8a-ap`
- `vendor/openvela/boards/vela/configs/qemu-arm64-v8a-server`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-ap`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-bl`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-server`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-tee`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v8m-ap`

## Result-aggregation fix for `post-processing`

`post-processing` previously read `needs.ci-tasks.outputs.status`, which is populated via the matrix job's `outputs:` block. Matrix instances share a single set of outputs and overwrite each other, so `status` only reflected whichever instance happened to finish last — not the true aggregate. A red group could easily be reported as `success`.

Fix:

- Read `needs.ci-tasks.result` instead. This is GitHub's built-in aggregate: `success` only when every matrix instance succeeds; any `failure` / `cancelled` in any group propagates.
- Pass `DEPENDS_ON` and `CURRENT_ACTION_URL` from `setup` directly (they were always originating there).
- Drop the now-redundant `ci-tasks.outputs` block and `Check status` step.

This makes the aggregation robust regardless of how many groups exist — future matrix changes need no updates to `post-processing`.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` passes.
- Group/task sanity check: `goldfish=3, qemu=7, sil=2, aurix=7, flagchip=2` (total 21 tasks).