### PR TITLE
ci: reorganize ci-real.yml matrix by vendor and add qemu builds

### DIFF
--- a/.github/workflows/ci-real.yml
+++ b/.github/workflows/ci-real.yml
@@ -210,23 +210,21 @@ jobs:
       DOCKER_BUILDKIT: 1
     strategy:
       matrix:
-        group: [ubuntu22-01, ubuntu22-02]  # 定义组
+        group: [goldfish, sil, aurix, flagchip, qemu]  # grouped by vendor / platform
         include:
-          - group: ubuntu22-01 # 第一组任务
+          - group: goldfish
             tasks:
               - goldfish-armeabi-v7a-ap@cmake
               - goldfish-arm64-v8a-ap@cmake
               - goldfish-x86_64-ap@cmake
-          - group: ubuntu22-02 # 第二组任务
+          - group: sil
             tasks:
               - vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_bl@cmake
               - vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_core0@cmake
               - vendor/openvela/boards/sil/configs/sil_arm32r_nsh_bl@cmake
               - vendor/openvela/boards/sil/configs/sil_arm32r_nsh_core0@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/bl@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/core0@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0@cmake
+          - group: aurix
+            tasks:
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/bl@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core0@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core1@cmake
@@ -234,11 +232,22 @@ jobs:
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core3@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core4@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core5@cmake
+          - group: flagchip
+            tasks:
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/bl@cmake
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/core0@cmake
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0@cmake
+          - group: qemu
+            tasks:
+              - qemu-arm64-v8a-ap@cmake
+              - qemu-arm64-v8a-server@cmake
+              - qemu-armeabi-v7a-ap@cmake
+              - qemu-armeabi-v7a-bl@cmake
+              - qemu-armeabi-v7a-server@cmake
+              - qemu-armeabi-v7a-tee@cmake
+              - qemu-armeabi-v8m-ap@cmake
       fail-fast: false
-    outputs:
-      status: ${{ steps.check.outputs.status }}
-      DEPENDS_ON: ${{ needs.setup.outputs.DEPENDS_ON }}
-      CURRENT_ACTION_URL: ${{ needs.setup.outputs.CURRENT_ACTION_URL }}
     steps:
       - name: Download Snapshot and PR Info
         uses: actions/download-artifact@v4
@@ -544,17 +553,12 @@ jobs:
           path: |
             ${{ matrix.group }}
 
-      - name: Check status
-        id: check
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-        run: |
-          echo "status=${JOB_STATUS}" >> $GITHUB_OUTPUT
-
-  # 后置处理作业，用于更新依赖PR状态
+  # Post-processing job to update dependent PR statuses.
+  # Uses needs.ci-tasks.result to aggregate results across all matrix
+  # groups: it is "success" only when every matrix instance succeeds;
+  # any failure or cancellation in any group makes it "failure".
   post-processing:
-    needs: ci-tasks
+    needs: [setup, ci-tasks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -568,9 +572,9 @@ jobs:
 
       - name: Post Processing
         env:
-          CI_TASKS_STATUS: ${{ needs.ci-tasks.outputs.status }}
-          DEPENDS_ON: ${{ needs.ci-tasks.outputs.DEPENDS_ON }}
-          CURRENT_ACTION_URL: ${{ needs.ci-tasks.outputs.CURRENT_ACTION_URL }}
+          CI_TASKS_STATUS: ${{ needs.ci-tasks.result }}
+          DEPENDS_ON: ${{ needs.setup.outputs.DEPENDS_ON }}
+          CURRENT_ACTION_URL: ${{ needs.setup.outputs.CURRENT_ACTION_URL }}
           CI_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           echo "Job status: ${CI_TASKS_STATUS}"


### PR DESCRIPTION
## Summary

Apply the same matrix reorganization and `post-processing` aggregation fix that landed in [open-vela/public-actions#58](https://github.com/open-vela/public-actions/pull/58) (to `trunk`) to the `dev` branch equivalent, which lives in `ci-real.yml`.

## Matrix reorganization

| group | count | notes |
|---|---|---|
| `goldfish` | 3 | Android goldfish emulator (unchanged) |
| `sil` | 4 | openvela SIL (`k*` + non-`k*` variants, moved out of old `ubuntu22-02`) |
| `aurix` | 7 | Infineon AURIX TC4D9 (moved out of old `ubuntu22-02`) |
| `flagchip` | 4 | Flagchip FC7300 (moved out of old `ubuntu22-02`) |
| `qemu` | 7 | **new** — qemu vela configs |

Benefits:
- 5 parallel runners instead of 2, shorter wall-clock time.
- Failures are easier to triage — the failing group name names the vendor.
- Build artifacts (`Build_Package_goldfish`, `Build_Package_qemu`, …) are now semantically named.

## Added build tasks (qemu group, all `@cmake`)

- `vendor/openvela/boards/vela/configs/qemu-arm64-v8a-ap`
- `vendor/openvela/boards/vela/configs/qemu-arm64-v8a-server`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-ap`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-bl`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-server`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v7a-tee`
- `vendor/openvela/boards/vela/configs/qemu-armeabi-v8m-ap`

## Result-aggregation fix for `post-processing`

Previously read `needs.ci-tasks.outputs.status`, populated via the matrix job's `outputs:` block. Matrix instances share a single set of outputs and overwrite each other, so `status` only reflected whichever instance happened to finish last, not the true aggregate. A red group could easily be reported as `success`.

Fix:
- Read `needs.ci-tasks.result` instead. This is GitHub's built-in aggregate: `success` only when every matrix instance succeeds; any `failure` / `cancelled` in any group propagates.
- Pass `DEPENDS_ON` and `CURRENT_ACTION_URL` from `setup` directly (they were always originating there).
- Drop the now-redundant `ci-tasks.outputs` block and `Check status` step.

This makes aggregation robust regardless of how many groups exist. Future matrix changes need no updates to `post-processing`.

## End-to-end validation

Run on a self-test workflow mirroring the same matrix + aggregation logic (live in a fork, no org secrets needed):

**Run:** https://github.com/liujinye-sys/public-actions/actions/runs/25424153926

| Job | Duration | Result |
|---|---|---|
| setup (repo init + sync + snapshot) | 3m49s | ✅ |
| ci-tasks (sil, 4 cfgs) | 13m27s | ✅ |
| ci-tasks (flagchip, 4 cfgs incl. `kcore0`) | 13m13s | ✅ |
| ci-tasks (aurix, 7 cfgs) | 26m53s | ✅ |
| ci-tasks (goldfish, 3 cfgs) | 30m47s | ✅ |
| ci-tasks (qemu, 7 new cfgs) | 38m50s | ✅ |
| post-processing | 3s | ✅ `needs.ci-tasks.result = success` |

Wall-clock time ≈ 42 min (setup + slowest group).