### PR TITLE
fix(ci): make CI status reporting accurate (vela_*.bin + post-processing exit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -493,7 +493,10 @@ jobs:
             if [[ "$task" == *:* ]] || [[ "$task" == *vendor/* ]]; then
               cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
             else
-              cp ${cp_base_dir}/nuttx ${cp_base_dir}/vela_*.bin ${cp_base_dir}/.config $ci_artifact_name
+              cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
+              # vela_*.bin is optional: only produced by full-image configs
+              # (e.g. goldfish). Configs like qemu-* only produce nuttx ELF.
+              cp ${cp_base_dir}/vela_*.bin $ci_artifact_name 2>/dev/null || true
             fi
 
             echo "=== Cleaning up after $task ==="
@@ -594,3 +597,13 @@ jobs:
               -d "{\"body\": \"$COMMENT_BODY\"}"
             set +x
           done
+
+          # Propagate the aggregated ci-tasks status to this job so that a
+          # single required status check on 'post-processing' is sufficient
+          # to gate merges. Without this, the job would be green even when
+          # any matrix instance failed, because status reporting was only
+          # done via curl to dependent PRs.
+          if [[ "$CI_TASKS_STATUS" != "success" ]]; then
+            echo "::error::CI failed: needs.ci-tasks.result = $CI_TASKS_STATUS"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

Observed on trunk after #58 merged: https://github.com/open-vela/packages_fe_examples/actions/runs/25427679424

Two issues stacked on top of each other caused a real CI failure to be reported as green on the PR page:

### A. `cp vela_*.bin` fails for configs that don't produce it

The artifact backup step copies `cmake_out/*/vela_*.bin` unconditionally for every non-vendor task. Only full-image configs like `goldfish-*` produce `vela_*.bin`. Configs like `qemu-*` only produce the `nuttx` ELF — the glob resolves to nothing, `cp` fails with `No such file or directory`, and the matrix job is marked failed even though the build succeeded.

```
#### build completed successfully (06:02 (mm:ss)) ####
...
cp: cannot stat 'cmake_out/*/vela_*.bin': No such file or directory
##[error]Process completed with exit code 1.
```

### B. `post-processing` stays green even when `ci-tasks` aggregated to `failure`

`post-processing` only reported status via curl to dependent PRs; its own shell script exited 0 regardless, so the job stayed green. Combined with the stale ruleset still pinning required checks to the now-removed `ci-tasks (ubuntu22-01/02)` names, PRs could merge with a failing matrix group (e.g. `qemu`).

## Fix

1. Always copy `nuttx` and `.config`; copy `vela_*.bin` best-effort with `|| true` so missing binaries are ignored.

   ```yaml
   cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
   cp ${cp_base_dir}/vela_*.bin $ci_artifact_name 2>/dev/null || true
   ```

2. Make `post-processing` itself fail when `needs.ci-tasks.result != success`:

   ```yaml
   if [[ "$CI_TASKS_STATUS" != "success" ]]; then
     echo "::error::CI failed: needs.ci-tasks.result = $CI_TASKS_STATUS"
     exit 1
   fi
   ```

## Branch ruleset guidance

After this lands, the required status check in the `ci-check-trunk` ruleset can be simplified to a single aggregate context:

- Remove `ci / ci_trunk / ci-tasks (ubuntu22-01)` and `(ubuntu22-02)` (they no longer exist after #58).
- Keep only `ci / ci_trunk / post-processing` as the aggregate gate, plus `cla/signature` and `checkpatch / checkpatch`.

That way, future matrix changes (adding or renaming vendor groups) don't require ruleset edits — the single required check tracks the true overall status.

## Companion PR

Same fix for `ci-real.yml` on `dev`: #61