### PR TITLE
fix(ci): make CI status reporting accurate in ci-real.yml

### DIFF
--- a/.github/workflows/ci-real.yml
+++ b/.github/workflows/ci-real.yml
@@ -502,7 +502,10 @@ jobs:
             if [[ "$task" == *:* ]] || [[ "$task" == *vendor/* ]]; then
               cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
             else
-              cp ${cp_base_dir}/nuttx ${cp_base_dir}/vela_*.bin ${cp_base_dir}/.config $ci_artifact_name
+              cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
+              # vela_*.bin is optional: only produced by full-image configs
+              # (e.g. goldfish). Configs like qemu-* only produce nuttx ELF.
+              cp ${cp_base_dir}/vela_*.bin $ci_artifact_name 2>/dev/null || true
             fi
 
             echo "=== Cleaning up after $task ==="
@@ -608,3 +611,13 @@ jobs:
               -d "{\"body\": \"$COMMENT_BODY\"}"
             set +x
           done
+
+          # Propagate the aggregated ci-tasks status to this job so that a
+          # single required status check on 'post-processing' is sufficient
+          # to gate merges. Without this, the job would be green even when
+          # any matrix instance failed, because status reporting was only
+          # done via curl to dependent PRs.
+          if [[ "$CI_TASKS_STATUS" != "success" ]]; then
+            echo "::error::CI failed: needs.ci-tasks.result = $CI_TASKS_STATUS"
+            exit 1
+          fi


### PR DESCRIPTION
## Problem

Companion to #60 on trunk — same two fixes applied to `ci-real.yml` on dev. After #59 (pending) lands qemu builds on `dev`, the same failure mode would occur here.

### A. `cp vela_*.bin` fails for configs that don't produce it

qemu-* configs only produce the `nuttx` ELF. The unconditional `cp cmake_out/*/vela_*.bin` resolves to nothing, `cp` errors out, and the matrix job is marked failed even though the build succeeded.

### B. `post-processing` stays green even when `ci-tasks` aggregated to `failure`

`post-processing` only curls dependent PRs; its own shell exits 0. Combined with required status checks still pinned to removed names, PRs could merge with a failing matrix group.

## Fix

1. Always copy `nuttx` and `.config`; copy `vela_*.bin` best-effort with `|| true`.
2. Make `post-processing` fail when `needs.ci-tasks.result != success`.

```yaml
if [[ "$CI_TASKS_STATUS" != "success" ]]; then
  echo "::error::CI failed: needs.ci-tasks.result = $CI_TASKS_STATUS"
  exit 1
fi
```

## Branch ruleset guidance

The `ci-check-dev` ruleset should then be simplified to require only:
- `ci / ci_dev / post-processing` (aggregate gate)
- `cla/signature`
- `checkpatch / checkpatch`

…and drop the old `ci-tasks (ubuntu22-01)` / `(ubuntu22-02)` entries. This way future matrix edits don't require ruleset edits.