### PR TITLE
ci: sync trunk CI changes to dev (matrix reorg + status reporting + manifest PR apply)

### DIFF
--- a/.github/workflows/ci-real.yml
+++ b/.github/workflows/ci-real.yml
@@ -210,23 +210,21 @@ jobs:
       DOCKER_BUILDKIT: 1
     strategy:
       matrix:
-        group: [ubuntu22-01, ubuntu22-02]  # 定义组
+        group: [goldfish, sil, aurix, flagchip, qemu]  # grouped by vendor / platform
         include:
-          - group: ubuntu22-01 # 第一组任务
+          - group: goldfish
             tasks:
               - goldfish-armeabi-v7a-ap@cmake
               - goldfish-arm64-v8a-ap@cmake
               - goldfish-x86_64-ap@cmake
-          - group: ubuntu22-02 # 第二组任务
+          - group: sil
             tasks:
               - vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_bl@cmake
               - vendor/openvela/boards/sil/configs/ksil_arm32r_nsh_core0@cmake
               - vendor/openvela/boards/sil/configs/sil_arm32r_nsh_bl@cmake
               - vendor/openvela/boards/sil/configs/sil_arm32r_nsh_core0@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/bl@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/core0@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake
-              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0@cmake
+          - group: aurix
+            tasks:
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/bl@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core0@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core1@cmake
@@ -234,11 +232,22 @@ jobs:
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core3@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core4@cmake
               - vendor/infineon/boards/aurix/tc4d9_evb/configs/core5@cmake
+          - group: flagchip
+            tasks:
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/bl@cmake
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/core0@cmake
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kbl@cmake
+              - vendor/flagchip/boards/fc7300/fc7300f8m-evb/configs/kcore0@cmake
+          - group: qemu
+            tasks:
+              - qemu-arm64-v8a-ap@cmake
+              - qemu-arm64-v8a-server@cmake
+              - qemu-armeabi-v7a-ap@cmake
+              - qemu-armeabi-v7a-bl@cmake
+              - qemu-armeabi-v7a-server@cmake
+              - qemu-armeabi-v7a-tee@cmake
+              - qemu-armeabi-v8m-ap@cmake
       fail-fast: false
-    outputs:
-      status: ${{ steps.check.outputs.status }}
-      DEPENDS_ON: ${{ needs.setup.outputs.DEPENDS_ON }}
-      CURRENT_ACTION_URL: ${{ needs.setup.outputs.CURRENT_ACTION_URL }}
     steps:
       - name: Download Snapshot and PR Info
         uses: actions/download-artifact@v4
@@ -544,17 +553,12 @@ jobs:
           path: |
             ${{ matrix.group }}
 
-      - name: Check status
-        id: check
-        if: always()
-        env:
-          JOB_STATUS: ${{ job.status }}
-        run: |
-          echo "status=${JOB_STATUS}" >> $GITHUB_OUTPUT
-
-  # 后置处理作业，用于更新依赖PR状态
+  # Post-processing job to update dependent PR statuses.
+  # Uses needs.ci-tasks.result to aggregate results across all matrix
+  # groups: it is "success" only when every matrix instance succeeds;
+  # any failure or cancellation in any group makes it "failure".
   post-processing:
-    needs: ci-tasks
+    needs: [setup, ci-tasks]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -568,9 +572,9 @@ jobs:
 
       - name: Post Processing
         env:
-          CI_TASKS_STATUS: ${{ needs.ci-tasks.outputs.status }}
-          DEPENDS_ON: ${{ needs.ci-tasks.outputs.DEPENDS_ON }}
-          CURRENT_ACTION_URL: ${{ needs.ci-tasks.outputs.CURRENT_ACTION_URL }}
+          CI_TASKS_STATUS: ${{ needs.ci-tasks.result }}
+          DEPENDS_ON: ${{ needs.setup.outputs.DEPENDS_ON }}
+          CURRENT_ACTION_URL: ${{ needs.setup.outputs.CURRENT_ACTION_URL }}
           CI_PAT: ${{ steps.app-token.outputs.token }}
         run: |
           echo "Job status: ${CI_TASKS_STATUS}"

--- a/.github/workflows/ci-real.yml
+++ b/.github/workflows/ci-real.yml
@@ -511,7 +511,10 @@ jobs:
             if [[ "$task" == *:* ]] || [[ "$task" == *vendor/* ]]; then
               cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
             else
-              cp ${cp_base_dir}/nuttx ${cp_base_dir}/vela_*.bin ${cp_base_dir}/.config $ci_artifact_name
+              cp ${cp_base_dir}/nuttx ${cp_base_dir}/.config $ci_artifact_name
+              # vela_*.bin is optional: only produced by full-image configs
+              # (e.g. goldfish). Configs like qemu-* only produce nuttx ELF.
+              cp ${cp_base_dir}/vela_*.bin $ci_artifact_name 2>/dev/null || true
             fi
 
             echo "=== Cleaning up after $task ==="
@@ -612,3 +615,13 @@ jobs:
               -d "{\"body\": \"$COMMENT_BODY\"}"
             set +x
           done
+
+          # Propagate the aggregated ci-tasks status to this job so that a
+          # single required status check on 'post-processing' is sufficient
+          # to gate merges. Without this, the job would be green even when
+          # any matrix instance failed, because status reporting was only
+          # done via curl to dependent PRs.
+          if [[ "$CI_TASKS_STATUS" != "success" ]]; then
+            echo "::error::CI failed: needs.ci-tasks.result = $CI_TASKS_STATUS"
+            exit 1
+          fi

--- a/.github/workflows/ci-real.yml
+++ b/.github/workflows/ci-real.yml
@@ -183,6 +183,21 @@ jobs:
         ~/bin/repo init -u https://github.com/open-vela/manifests -b "$PR_BASE_REF" -m openvela.xml --group=default,platform-linux --depth=1 --git-lfs
         echo "REPO_INIT=true" >> $GITHUB_ENV
 
+    - name: Apply manifest PR before sync
+      if: ${{ github.event_name == 'pull_request_target' && github.repository == 'open-vela/manifests' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        git config --global user.email "openvela-robot@xiaomi.com"
+        git config --global user.name "openvela-robot"
+        cd .repo/manifests
+        git fetch origin pull/$PR_NUMBER/head:pr-branch
+        git cherry-pick $(git rev-list --reverse HEAD..$PR_HEAD_SHA) || true
+        cd -
+
     - name: Repo Sync
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Sync the CI workflow changes already merged on `trunk` to `dev`, consolidating the three existing PRs (#55, #59, #61) into a single review.

All three touch only `.github/workflows/ci-real.yml` and share the same base SHA, so they are cherry-picked into one branch in the natural merge order.

## Commits

1. **ci: reorganize matrix by vendor and add qemu builds** — mirrors trunk `14d267f`
   - matrix: `ubuntu22-01/02` → `goldfish/sil/aurix/flagchip/qemu` (5 parallel runners)
   - adds 7 `qemu-*` configs under the new `qemu` group
   - retains `flagchip/kcore0` (vendor fix landed, consistent with trunk tip)
   - `post-processing` now reads `needs.ci-tasks.result` instead of matrix outputs
   - drops redundant `ci-tasks.outputs` block and `Check status` step

2. **fix(ci): make CI status reporting accurate** — mirrors trunk `1790b2f`
   - `cp vela_*.bin … || true` so qemu-* configs (which don't produce `vela_*.bin`) don't fail the artifact backup
   - `post-processing` exits `1` when `needs.ci-tasks.result != success`, so a single required check (`ci / ci_dev / post-processing`) correctly gates merges

3. **fix(ci): apply manifest PR before repo sync in setup job** — mirrors trunk `5842463`
   - new `Apply manifest PR before sync` step cherry-picks manifest PR changes before `repo sync`, so snapshots include newly added projects (e.g. `build`)
   - only runs when PR is from `open-vela/manifests`

## Replaces

- Closes #55
- Closes #59
- Closes #61

All three PRs are open but pending, with the same base SHA and no conflicts between them.

## Verification

- Each commit mirrors a commit already merged on `trunk` via the corresponding trunk PR (#58, #60, and the manifest-apply fix).
- Matrix/aggregation logic was previously verified end-to-end in the self-test fork run: [liujinye-sys/public-actions/actions/runs/25424153926](https://github.com/liujinye-sys/public-actions/actions/runs/25424153926) — all 5 groups pass, `post-processing` aggregates via `needs.ci-tasks.result`.

## Branch ruleset follow-up

Once merged, `ci-check-dev` ruleset can be simplified to require only:

- `ci / ci_dev / post-processing` (aggregate gate)
- `cla/signature`
- `checkpatch / checkpatch`

and drop the old `ci-tasks (ubuntu22-01/02)` entries. Future matrix edits then need no ruleset updates.

Related-to: open-vela/public-actions#58, open-vela/public-actions#60