### PR TITLE
ci: allow dev-derived base refs to trigger ci_dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
 
   ci_dev:
     # 只在 PR 时执行，评论不触发 CI
-    if: (github.event_name == 'pull_request_target' || github.event_name == 'workflow_call') && github.event.pull_request.base.ref == 'dev'
+    # 支持 dev 及派生分支（如 dev-ai-contest-2026 等）
+    if: (github.event_name == 'pull_request_target' || github.event_name == 'workflow_call') && (github.event.pull_request.base.ref == 'dev' || startsWith(github.event.pull_request.base.ref, 'dev-'))
     uses: open-vela/public-actions/.github/workflows/ci-real.yml@dev
     secrets: inherit


### PR DESCRIPTION
## Summary

Extend `ci_dev` branch filter to accept `dev` **and** any base branch that starts with `dev-`.

## Background

To support the AI contest, I created a new branch `dev-ai-contest-2026` on all openvela project repos (254) and on `manifests`, with `manifests/openvela.xml` default revision switched to `dev-ai-contest-2026`. However the dispatcher `ci.yml` currently hardcodes `base.ref == 'dev'`, so PRs targeting `dev-ai-contest-2026` (or any future `dev-xxx` branch) would not trigger CI.

The reusable `ci-real.yml` already passes `PR_BASE_REF` into `repo init -b "$PR_BASE_REF"`, so code download is already branch-aware. Only the dispatcher guard needs to widen.

## Change

```yaml
# before
if: ... && github.event.pull_request.base.ref == 'dev'

# after
if: ... && (github.event.pull_request.base.ref == 'dev'
            || startsWith(github.event.pull_request.base.ref, 'dev-'))
```

## Test plan

- Open a test PR against `dev-ai-contest-2026` on any project repo after this merges to confirm `ci_dev` job runs and `repo init -b dev-ai-contest-2026` succeeds.
- PRs against `dev` remain unchanged.
- PRs against `trunk` / `rebase_dev_trunk*` remain routed to `ci_trunk`.