### PR TITLE
fix(check_commit_msg): detect Chinese in multi-line commit body

### DIFF
--- a/check_commit_msg.py
+++ b/check_commit_msg.py
@@ -1,99 +1,111 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-import sys
-import subprocess
-import re
-import argparse
+"""Check whether any commit message within a range contains Chinese characters.
 
-# 中文字符的 Unicode 范围
-# 这个范围包含了大部分常见的中日韩（CJK）统一表意文字。
+The previous implementation used ``git log --pretty=format:%H%x00%B`` and split
+the output by newline, but ``%B`` (commit body) itself contains newlines. As a
+result the multi-line body was broken into separate entries and the entries
+without a NUL separator were silently dropped, causing Chinese in the body to
+go undetected.
+
+This version enumerates commits explicitly with ``git rev-list`` and reads each
+commit message independently with ``git log -1 --format=%B``, so the full
+message (including the body) is always checked.
+"""
+import argparse
+import re
+import subprocess
+import sys
+
+# CJK Unified Ideographs covers the common set of Chinese characters.
 CHINESE_CHAR_PATTERN = re.compile(r'[\u4e00-\u9fff]')
 
-def contains_chinese(text):
-    """
-    检查给定文本中是否包含中文字符。
-    """
-    if text and CHINESE_CHAR_PATTERN.search(text):
-        return True
-    return False
 
-def get_commit_messages(commit_range):
+def contains_chinese(text: str) -> bool:
+    """Return True if ``text`` contains any Chinese character."""
+    return bool(text and CHINESE_CHAR_PATTERN.search(text))
+
+
+def run_git(args):
+    """Run a git command and return its stdout as text.
+
+    Exits the process with an error message when git fails so that CI surfaces
+    the failure clearly.
     """
-    使用 git log 获取指定范围内的所有 commit 信息。
-    返回一个包含 (commit_hash, commit_message) 元组的列表。
-    """
-    # 使用 %H 获取完整的 commit hash
-    # 使用 %B 获取完整的 commit message (包括 subject 和 body)
-    # 使用 %x00 作为分隔符，这是最稳妥的方式，可以避免 message 中的特殊字符干扰
-    command = ["git", "log", "--pretty=format:%H%x00%B", commit_range]
     try:
         result = subprocess.run(
-            command,
+            ["git", *args],
             capture_output=True,
             text=True,
-            encoding='utf-8',
-            check=True  # 如果 git 命令失败，则抛出异常
+            encoding="utf-8",
+            check=True,
         )
     except FileNotFoundError:
-        print("错误: 'git' 命令未找到。请确保 Git 已经安装并且在系统的 PATH 中。", file=sys.stderr)
+        print(
+            "Error: 'git' command not found. Please ensure Git is installed "
+            "and on PATH.",
+            file=sys.stderr,
+        )
         sys.exit(1)
-    except subprocess.CalledProcessError as e:
-        print(f"错误: 'git log' 执行失败。\n{e.stderr}", file=sys.stderr)
+    except subprocess.CalledProcessError as exc:
+        print(
+            f"Error: 'git {' '.join(args)}' failed.\n{exc.stderr}",
+            file=sys.stderr,
+        )
         sys.exit(1)
+    return result.stdout
 
-    output = result.stdout.strip()
+
+def get_commit_hashes(commit_range: str):
+    """Return the list of commit hashes contained in ``commit_range``."""
+    output = run_git(["rev-list", commit_range]).strip()
     if not output:
         return []
+    return output.splitlines()
 
-    commits = []
-    # 按换行符分割每个 commit 条目
-    for entry in output.split('\n'):
-        # 按 null 字节分割 hash 和 message
-        parts = entry.split('\x00', 1)
-        if len(parts) == 2:
-            commit_hash, commit_message = parts
-            commits.append((commit_hash, commit_message))
 
-    return commits
+def get_commit_message(commit_hash: str) -> str:
+    """Return the full commit message (subject + body) for ``commit_hash``."""
+    return run_git(["log", "-1", "--format=%B", commit_hash])
 
-def main():
-    """
-    主函数
-    """
+
+def main() -> None:
     parser = argparse.ArgumentParser(
-        description="检查 Git commit messages 中是否包含中文字符。"
+        description=(
+            "Check whether any commit message in the given range contains "
+            "Chinese characters."
+        ),
     )
     parser.add_argument(
         "commit_range",
-        help="要检查的 Git commit 范围 (例如: 'main..HEAD' 或 'commit1..commit2')。"
+        help="Git commit range to inspect, e.g. 'main..HEAD' or 'A..B'.",
     )
-
     args = parser.parse_args()
 
-    print(f"--- 正在检查 commit 范围: {args.commit_range} ---")
+    print(f"--- Checking commit range: {args.commit_range} ---")
 
-    commits_to_check = get_commit_messages(args.commit_range)
-
-    if not commits_to_check:
-        print("没有找到需要检查的 commits。")
+    hashes = get_commit_hashes(args.commit_range)
+    if not hashes:
+        print("No commits to check.")
         sys.exit(0)
 
     found_error = False
-    for commit_hash, message in commits_to_check:
+    for commit_hash in hashes:
+        message = get_commit_message(commit_hash)
         if contains_chinese(message):
             found_error = True
-            print("\n❌ 检查失败: Commit 中包含中文字符！")
+            print("\n❌ Check failed: commit message contains Chinese characters.")
             print(f"   Commit Hash: {commit_hash}")
-            # 只显示 message 的前 100 个字符以保持简洁
-            print(f"   Message (部分): {message.strip()[:100]}...")
+            # Truncate to keep log output readable.
+            print(f"   Message (truncated): {message.strip()[:100]}...")
 
     if found_error:
-        print("\n--- 检查未通过 ---")
+        print("\n--- Check failed ---")
         sys.exit(1)
-    else:
-        print("\n✅ 所有 Commit Message 均符合规范，未检测到中文字符。")
-        print("--- 检查通过 ---")
-        sys.exit(0)
+    print("\n✅ All commit messages pass: no Chinese characters detected.")
+    print("--- Check passed ---")
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary

`check_commit_msg.py` was parsing `git log --pretty=format:%H%x00%B` by splitting on `\n`, but `%B` contains newlines itself. Body lines without the NUL separator were silently dropped by the `len(parts) == 2` filter, so any Chinese characters in the commit body went undetected.

Enumerate commits explicitly via `git rev-list` and read each message independently with `git log -1 --format=%B`, so the full subject + body is always checked.

## Evidence

PR [open-vela/vendor_openvela#56](https://github.com/open-vela/vendor_openvela/pull/56) had the following commit:

```
Create test-ci

中文测试
```

Yet CI [job 75489039642](https://github.com/open-vela/vendor_openvela/actions/runs/25710344174/job/75489039642) reported:

```
--- 正在检查 commit 范围: e4d62a8..HEAD ---
✅ 所有 Commit Message 均符合规范，未检测到中文字符。
```

## Impact

- Fixes false negative on commit messages whose body contains Chinese.
- Output messages switched to English for consistency with the file's ASCII nature; the behavior and exit codes are unchanged.
- `chinese-detector:dev` Docker image must be rebuilt and pushed (handled by `build-chinese-detection-docker.yml` on merge to `dev`).

## Testing

Local repro with subject English + body Chinese — script now exits 1:
```
--- Checking commit range: <base>..HEAD ---
❌ Check failed: commit message contains Chinese characters.
   Commit Hash: 666c1d15...
   Message (truncated): Create test-ci

中文测试...
--- Check failed ---
```

Pure-English commit still passes (exit 0).
