### PR TITLE
ci(checkpatch): skip source-file Chinese check for packages_apps

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -96,6 +96,10 @@ jobs:
           echo "✅ Commit message check passed"
 
     - name: Check Chinese in Source Files
+      # packages_apps hosts Quick App (快应用) code where Chinese UI strings
+      # and keywords are unavoidable, so source-file Chinese check is skipped
+      # for that repo. Commit message check above still runs.
+      if: ${{ env.REPO_NAME != 'packages_apps' }}
       run: |
           cd ${{ env.REPO_NAME }}
           commits="${{ github.event.pull_request.base.sha }}..HEAD"


### PR DESCRIPTION
## Summary

`open-vela/packages_apps` hosts Quick App (快应用) code. Chinese UI strings and Quick App keywords are unavoidable in that domain, so the source-file Chinese detection step causes persistent false positives there.

Skip `Check Chinese in Source Files` when `REPO_NAME == packages_apps`. All other repos behave as before.

## Impact

- `packages_apps`: source-file Chinese check is skipped. **Commit message Chinese check is still enforced.**
- All other repos: unchanged (both checks continue to run).
- Watermark, checkpatch, and the `Check PR` Change-Id guard are untouched.

## Testing

- `grep -n "REPO_NAME != 'packages_apps'"` confirms the guard lives only on the source-file step.
- Other steps (watermark, commit-message Chinese, final check) have no `if:` condition and still run for every repo.
