### PR TITLE
ci(checkpatch): skip source-file Chinese check for packages_ai_agent

### DIFF
--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -96,10 +96,12 @@ jobs:
           echo "✅ Commit message check passed"
 
     - name: Check Chinese in Source Files
-      # packages_apps hosts Quick App (快应用) code where Chinese UI strings
-      # and keywords are unavoidable, so source-file Chinese check is skipped
-      # for that repo. Commit message check above still runs.
-      if: ${{ env.REPO_NAME != 'packages_apps' }}
+      # Some repos legitimately need Chinese in source files, so the
+      # source-file Chinese check is skipped for them. The commit
+      # message check above still runs for every repo.
+      #   - packages_apps: Quick App (快应用) UI strings and keywords
+      #   - packages_ai_agent: AI agent content in Chinese is unavoidable
+      if: ${{ env.REPO_NAME != 'packages_apps' && env.REPO_NAME != 'packages_ai_agent' }}
       run: |
           cd ${{ env.REPO_NAME }}
           commits="${{ github.event.pull_request.base.sha }}..HEAD"


### PR DESCRIPTION
## Problem

`packages_ai_agent` (https://github.com/open-vela/packages_ai_agent) hosts AI agent content where Chinese strings in source files are unavoidable. The current `Check Chinese in Source Files` step in `checkpatch.yml` fails CI for such legitimate content.

## Fix

Extend the existing skip condition (already used for `packages_apps`) so the source-file Chinese check is also skipped for `packages_ai_agent`:

```yaml
if: ${{ env.REPO_NAME != 'packages_apps' && env.REPO_NAME != 'packages_ai_agent' }}
```

The **commit message** Chinese check is unchanged and still enforced for every repo, including `packages_ai_agent`. All other repositories continue to run both checks.

## Notes

- Follows the per-repo `if:` exemption pattern instead of adding a repo allowlist inside the generic `check_source_files.py`, keeping the shared script clean.
- YAML validated locally.