### PR TITLE
CI: add testbuild-driven reusable OpenVela CI workflows

### DIFF
--- a/.github/workflows/docker_linux.yml
+++ b/.github/workflows/docker_linux.yml
@@ -18,13 +18,23 @@
 name: Docker-Linux
 
 on:
+  workflow_dispatch:
   push:
-    # Publish `trunk` as Docker `latest` image.
     branches:
-      - trunk
+      - dev
     paths:
       - '.github/workflows/docker_linux.yml'
       - '.github/workflows/docker_linux/Dockerfile'
+      - '.github/workflows/docker_linux/scripts/**'
+      - '.github/actions/free-disk-space/**'
+
+  # Build, but do not publish, for any PR touching the image.
+  pull_request:
+    paths:
+      - '.github/workflows/docker_linux.yml'
+      - '.github/workflows/docker_linux/Dockerfile'
+      - '.github/workflows/docker_linux/scripts/**'
+      - '.github/actions/free-disk-space/**'
 
 env:
   IMAGE_NAME: openvela-ci-linux
@@ -42,7 +52,7 @@ jobs:
   push:
     runs-on: ubuntu-latest
     env:
-      IMAGE_TAG: ghcr.io/open-vela/openvela-ci-linux
+      IMAGE_TAG: ghcr.io/${{ github.repository_owner }}/openvela-ci-linux
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -75,13 +85,21 @@ jobs:
       - name: Pre-build Disk Stats
         run: |
           df -h
+      - name: Compute image tag
+        id: imagetag
+        run: |
+          # PR refs are N/merge; slashes are not valid in a tag.
+          echo "tag=${GITHUB_REF_NAME//\//-}" >> "${GITHUB_OUTPUT}"
+
       - name: Push Linux image
         uses: docker/build-push-action@v6
         with:
           context: .github/workflows/docker_linux
           platforms: linux/amd64
-          push: ${{ github.ref == 'refs/heads/trunk' }}
-          tags: ${{ env.IMAGE_TAG }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ${{ env.IMAGE_TAG }}:${{ steps.imagetag.outputs.tag }}
+            ${{ env.IMAGE_TAG }}:sha-${{ github.sha }}
       - name: Post-build Disk Stats
         if: always()
         run: |

--- a/.github/workflows/docker_linux/Dockerfile
+++ b/.github/workflows/docker_linux/Dockerfile
@@ -19,444 +19,157 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
 # License for the specific language governing permissions and limitations
 # under the License.
+#
+# OpenVela development and CI base image.
+#
+# This image intentionally installs host dependencies only. OpenVela source,
+# compiler toolchains, QEMU prebuilts, CMake prebuilts, build-tools, and
+# emulator prebuilts are synced by repo from open-vela/manifests.
 
-FROM ubuntu:22.04 AS builder-base
-# NOTE WE ARE NOT REMOVEING APT CACHE.
-# This should only be used for temp build images that artifacts will be copied from
-RUN apt-get update -qq && apt-get install -y -qq \
-  curl \
-  patch \
-  xz-utils
-
-###############################################################################
-# Base image that should be used to prepare tools from openvela-tools
-###############################################################################
-FROM builder-base AS openvela-tools
-
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
-  bison \
-  clang \
-  cmake \
-  flex \
-  g++ \
-  gawk \
-  git \
-  gperf \
-  libncurses5-dev \
-  make \
-  ninja-build \
-  nodejs \
-  npm \
-  unzip
-
-RUN mkdir -p /tools
-WORKDIR /tools
-
-RUN mkdir -p /tools/openvela-tools
-
-RUN mkdir -p /tools/bloaty \
-  && git clone --depth 1 --branch v1.1 https://github.com/google/bloaty bloaty-src \
-  && cd bloaty-src \
-  && cmake -B build -DCMAKE_INSTALL_PREFIX=/tools/bloaty \
-  && cmake --build build \
-  && cmake --build build --target install \
-  && cd /tools && rm -rf bloaty-src
-
-RUN mkdir -p /tools/gn \
-  && cd /tools/gn \
-  && git clone https://gn.googlesource.com/gn gn \
-  && cd gn && ./build/gen.py \
-  && cd out && ninja
-
-ENV ZAP_INSTALL_PATH=/tools/zap_release
-RUN mkdir -p $ZAP_INSTALL_PATH \
-  && cd $ZAP_INSTALL_PATH \
-  && curl -s -O -L https://github.com/project-chip/zap/releases/download/v2023.10.09-nightly/zap-linux-x64.zip \
-  && unzip zap-linux-x64.zip \
-  && rm zap-linux-x64.zip
-
-ENV ZAP_DEVELOPMENT_PATH=/tools/zap
-RUN cd /tools \
-  && curl -s -O -L https://github.com/project-chip/zap/archive/refs/tags/v2023.10.09-nightly.zip \
-  && unzip v2023.10.09-nightly.zip \
-  && mv zap-2023.10.09-nightly zap \
-  && rm v2023.10.09-nightly.zip \
-  && cd zap && npm install cross-spawn folder-hash
-
-#########################
-# Programming languages
-#########################
-
-# Install Rust and targets supported from openvela
-ENV RUST_HOME=/tools/rust
-ENV CARGO_HOME=$RUST_HOME/cargo
-ENV RUSTUP_HOME=$RUST_HOME/rustup
-RUN mkdir -p $CARGO_HOME \
-  && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
-  && $CARGO_HOME/bin/rustup target add thumbv6m-none-eabi \
-  && $CARGO_HOME/bin/rustup target add thumbv7m-none-eabi \
-  && $CARGO_HOME/bin/rustup target add riscv64gc-unknown-none-elf
-
-# Install Swift
-# ENV SWIFT_VERSION=6.0-DEVELOPMENT-SNAPSHOT-2024-08-22-a
-# ENV SWIFT_HOME=/tools/swift
-# RUN mkdir -p ${SWIFT_HOME} \
-#  && curl -s -O -L https://download.swift.org/swift-6.0-branch/ubuntu2204/swift-${SWIFT_VERSION}/swift-${SWIFT_VERSION}-ubuntu22.04.tar.gz \
-#  && tar xzf swift-${SWIFT_VERSION}-ubuntu22.04.tar.gz -C ${SWIFT_HOME} \
-#  && rm swift-${SWIFT_VERSION}-ubuntu22.04.tar.gz
-
-# Install Zig latest release
-ENV ZIG_VERSION=0.13.0
-ENV ZIG_HOME=/tools/zig
-RUN mkdir -p ${ZIG_HOME} \
-  && curl -s -O -L https://github.com/marler8997/zigup/releases/download/v2024_05_05/zigup-x86_64-linux.tar.gz \
-  && tar xzf zigup-x86_64-linux.tar.gz -C ${ZIG_HOME} \
-  && rm zigup-x86_64-linux.tar.gz \
-  && chmod +x ${ZIG_HOME}/zigup \
-  && ${ZIG_HOME}/zigup fetch --install-dir ${ZIG_HOME} ${ZIG_VERSION} \
-  && chmod +x ${ZIG_HOME}/${ZIG_VERSION}/files/zig
-
-# Install LDC2 latest release
-ENV LDC_VERSION=1.39.0
-ENV D_HOME=/tools/ldc2
-RUN mkdir -p ${D_HOME} \
-  && curl -s -O -L https://github.com/ldc-developers/ldc/releases/download/v${LDC_VERSION}/ldc2-${LDC_VERSION}-linux-x86_64.tar.xz \
-  && tar xf ldc2-${LDC_VERSION}-linux-x86_64.tar.xz -C ${D_HOME} \
-  && rm ldc2-${LDC_VERSION}-linux-x86_64.tar.xz
-
-CMD [ "/bin/bash" ]
-
-###############################################################################
-# Base image that should be used to prepare arch build images
-###############################################################################
-FROM builder-base AS openvela-toolchain-base
-
-RUN mkdir -p /tools
-WORKDIR /tools
-
-###############################################################################
-# Build image for tool required by ARM builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-arm
-# Download the latest ARM clang toolchain prebuilt by ARM
-RUN mkdir -p clang-arm-none-eabi && \
-  curl -s -L  "https://github.com/ARM-software/LLVM-embedded-toolchain-for-Arm/releases/download/release-17.0.1/LLVMEmbeddedToolchainForArm-17.0.1-Linux-x86_64.tar.xz" \
-  | tar -C clang-arm-none-eabi --strip-components 1 -xJ
-
-# Download the latest ARM GCC toolchain prebuilt by ARM
-RUN mkdir -p gcc-arm-none-eabi && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1-x86_64-arm-none-eabi.tar.xz" \
-  | tar -C gcc-arm-none-eabi --strip-components 1 -xJ
-
-###############################################################################
-# Build image for tool required by ARM64 builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-arm64
-# Download the latest ARM64 GCC toolchain prebuilt by ARM
-RUN mkdir gcc-aarch64-none-elf && \
-  curl -s -L  "https://developer.arm.com/-/media/Files/downloads/gnu/13.2.Rel1/binrel/arm-gnu-toolchain-13.2.Rel1-x86_64-aarch64-none-elf.tar.xz" \
-  | tar -C gcc-aarch64-none-elf --strip-components 1 -xJ
-
-###############################################################################
-# Build image for tool required by AVR32 builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-avr32
-# Download the prebuilt AVR32 GCC toolchain
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
-  git
-# Clone Main Repository
-RUN mkdir -p gcc-avr32-gnu && \
-  git clone --depth 1 https://github.com/ramangopalan/avr32-gnu-toolchain-linux_x86 gcc-avr32-gnu
-
-###############################################################################
-# Build image for tool required by Pinguino builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-pinguino
-# Download the pinguino compilers. Note this includes both 8bit and 32bit
-# toolchains and builds for multiple host systems. Only copy what is needed.
-RUN mkdir -p pinguino-compilers && \
-  curl -s -L "https://github.com/PinguinoIDE/pinguino-compilers/archive/62db5158d7f6d41c6fadb05de81cc31dd81a1958.tar.gz" \
-  | tar -C pinguino-compilers --strip-components=2 --wildcards -xz */linux64
-
-###############################################################################
-# Build image for tool required by Renesas builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-renesas
-# Build Renesas RX GCC toolchain
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
-  bison \
-  flex \
-  g++ \
-  gcc \
-  libncurses5-dev \
-  m4 \
-  make \
-  texinfo \
-  wget \
-  bzip2
-
-# Download toolchain source code
-RUN mkdir -p /tools/renesas-tools/source/binutils && \
-  curl -s -L "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/binutils/8.3.0.202305-gnurx/binutils-2.36.1.tar.gz" \
-  | tar -C renesas-tools/source/binutils --strip-components=1 -xz
-RUN mkdir -p /tools/renesas-tools/source/gcc && \
-  curl -s -L "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/gcc/8.3.0.202305-gnurx/gcc-8.3.0.tar.gz" \
-  | tar -C renesas-tools/source/gcc --strip-components=1 -xz
-RUN mkdir -p /tools/renesas-tools/source/newlib && \
-  curl -s -L "https://llvm-gcc-renesas.com/downloads/d.php?f=rx/newlib/8.3.0.202305-gnurx/newlib-4.1.0.tar.gz" \
-  | tar -C renesas-tools/source/newlib --strip-components=1 -xz
-
-# Install binutils
-RUN cd renesas-tools/source/binutils && \
-  chmod +x ./configure ./mkinstalldirs && \
-  mkdir -p /tools/renesas-tools/build/binutils && cd /tools/renesas-tools/build/binutils && \
-  /tools/renesas-tools/source/binutils/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc --disable-werror &&\
-  make && make install
-ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
-
-# Install gcc
-RUN cd renesas-tools/source/gcc && \
-  chmod +x ./contrib/download_prerequisites ./configure ./move-if-change ./libgcc/mkheader.sh && \
-  ./contrib/download_prerequisites && \
-  sed -i '1s/^/@documentencoding ISO-8859-1\n/' ./gcc/doc/gcc.texi && \
-  sed -i 's/@tex/\n&/g' ./gcc/doc/gcc.texi && sed -i 's/@end tex/\n&/g' ./gcc/doc/gcc.texi && \
-  mkdir -p /tools/renesas-tools/build/gcc && cd /tools/renesas-tools/build/gcc && \
-  /tools/renesas-tools/source/gcc/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc \
-  --disable-shared --disable-multilib --disable-libssp --disable-libstdcxx-pch --disable-werror --enable-lto \
-  --enable-gold --with-pkgversion=GCC_Build_1.02 --with-newlib --enable-languages=c && \
-  make && make install
-ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
-
-# Install newlib
-RUN cd renesas-tools/source/newlib && \
-  chmod +x ./configure && \
-  mkdir -p /tools/renesas-tools/build/newlib && cd /tools/renesas-tools/build/newlib && \
-  /tools/renesas-tools/source/newlib/configure --target=rx-elf --prefix=/tools/renesas-toolchain/rx-elf-gcc && \
-  make && make install
-RUN cd /tools/renesas-tools/build/gcc && \
-  make && make install && cd /tools && rm -rf renesas-tools
-
-###############################################################################
-# Build image for tool required by RISCV builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-riscv
-# Download the latest RISCV GCC toolchain prebuilt by xPack
-RUN mkdir -p riscv-none-elf-gcc && \
-  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v13.2.0-2/xpack-riscv-none-elf-gcc-13.2.0-2-linux-x64.tar.gz" \
-  | tar -C riscv-none-elf-gcc --strip-components 1 -xz
-
-###############################################################################
-# Build image for tool required by SPARC builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-sparc
-# Download the SPARC GCC toolchain prebuilt by Gaisler
-RUN mkdir -p sparc-gaisler-elf-gcc && \
-  curl -s -L "https://www.gaisler.com/anonftp/bcc2/bin/bcc-2.1.0-gcc-linux64.tar.xz" \
-  | tar -C sparc-gaisler-elf-gcc --strip-components 1 -xJ
-
-###############################################################################
-# Build image for tool required by WASM builds
-###############################################################################
-FROM openvela-toolchain-base AS openvela-toolchain-wasm
-# Download the latest WASI-enabled WebAssembly C/C++ toolchain prebuilt by WASM
-RUN mkdir -p wasi-sdk && \
-  curl -s -L  "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-19/wasi-sdk-19.0-linux.tar.gz" \
-  | tar -C wasi-sdk --strip-components 1 -xz
-
-# Download the latest "wamrc" AOT compiler prebuilt by WAMR
-RUN mkdir -p wamrc && \
-  curl -s -L  "https://github.com/bytecodealliance/wasm-micro-runtime/releases/download/WAMR-1.1.2/wamrc-1.1.2-x86_64-ubuntu-20.04.tar.gz" \
-  | tar -C wamrc -xz
-
-###############################################################################
-# Final Docker image used for running CI system.  This includes all toolchains
-# supported by the CI system.
-###############################################################################
 FROM ubuntu:22.04
 
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -qq \
-  build-essential \
-  curl \
-  gcc \
-  libssl-dev
+ARG OPENVELA_UID=1000
+ARG OPENVELA_GID=1000
 
-RUN mkdir -p cmake && \
-  curl -s -L https://cmake.org/files/v3.26/cmake-3.26.0.tar.gz \
-  | tar -C cmake --strip-components=1 -xz \
-  && cd cmake && ./bootstrap && make && make install && rm -rf cmake
-
-RUN dpkg --add-architecture i386
-# This is used for the final images so make sure to not store apt cache
-# Note: xtensa-esp32-elf-gdb is linked to libpython2.7
-RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" TZ=Etc/UTC apt-get install -y -qq --no-install-recommends \
-  -o APT::Immediate-Configure=0 \
-  avr-libc \
-  ccache \
-  clang \
-  clang-tidy \
-  g++-12-multilib \
-  gcc-avr \
-  gcc-12-multilib \
-  genromfs \
-  gettext \
-  git \
-  lib32z1-dev \
-  libasound2-dev libasound2-dev:i386 \
-  libc6-dev-i386 \
-  libcurl4-openssl-dev \
-  libmp3lame-dev:i386 \
-  libmad0-dev:i386 \
-  libncurses5-dev \
-  libpulse-dev libpulse-dev:i386 \
-  libpython2.7 \
-  libtinfo5 \
-  libusb-1.0-0-dev libusb-1.0-0-dev:i386 \
-  libv4l-dev libv4l-dev:i386 \
-  libx11-dev libx11-dev:i386 \
-  libxext-dev libxext-dev:i386 \
-  linux-headers-generic \
-  linux-libc-dev:i386 \
-  ninja-build \
-  npm \
-  qemu-system-arm \
-  qemu-system-misc \
-  python3 \
-  python3-pip \
-  python-is-python3 \
-  u-boot-tools \
-  unzip \
-  wget \
-  xxd \
-  file \
-  subversion \
-  tclsh \
-  kconfig-frontends \
-  jq \
-  git-lfs
-RUN git lfs install
-RUN git lfs --version
-RUN rm -rf /var/lib/apt/lists/*
-
-# Set GCC-12 as Default compiler
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 && \
-  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 20 && \
-  update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 30 && \
-  update-alternatives --set cc /usr/bin/gcc && \
-  update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 30 && \
-  update-alternatives --set c++ /usr/bin/g++
-
-# Configure out base setup for adding python packages
+ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_DISABLE_PIP_VERSION_CHECK=true
-# This disables the cache with value 0. We do not want caching as it
-# increases the images size.
-ENV PIP_NO_CACHE_DIR=0
-# We are using the minimal python installation from the system so include
-# setuptools and also wheel so we can use the binary releases of packages
-# instead of requiring them to be compiled.
-RUN pip3 install setuptools
-RUN pip3 install wheel
-RUN pip3 install cmake-format
-# Install CodeChecker and use it to statically analyze the code.
-# RUN pip3 install CodeChecker
-# Install cvt2utf to check for non-UTF characters.
-RUN pip3 install cvt2utf
-# Install pytest
-RUN pip3 install cxxfilt
-RUN pip3 install esptool==4.8.dev4
-RUN pip3 install html-table
-RUN pip3 install imgtool
-RUN pip3 install kconfiglib
-RUN pip3 install matplotlib==3.6.2
-RUN pip3 install pexpect==4.8.0
-RUN pip3 install pyelftools
-RUN pip3 install pyserial==3.5
-RUN pip3 install pytest==6.2.5
-RUN pip3 install pytest-json==0.4.0
-RUN pip3 install pytest-ordering==0.6
-RUN pip3 install pytest-repeat==0.9.1
-# Install lark stringcase jinja2 and coloredlogs for matter build
-RUN pip3 install lark
-RUN pip3 install stringcase
-RUN pip3 install jinja2
-RUN pip3 install coloredlogs
+ENV PIP_NO_CACHE_DIR=1
+ENV LANG=C.UTF-8
+ENV LC_ALL=C.UTF-8
+ENV HOME=/home/openvela
 
-# Upgrade nodejs to the latest version
-RUN npm install -g n && n stable && hash -r
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Used to generate symbol table files
+# For the 32-bit sim configs (CONFIG_SIM_M32=y).
+RUN dpkg --add-architecture i386
 
-RUN mkdir -p /tools
-WORKDIR /tools
+RUN apt-get update -qq \
+  && apt-get install -y -qq --no-install-recommends \
+    autoconf \
+    automake \
+    bison \
+    build-essential \
+    ca-certificates \
+    cmake \
+    curl \
+    dfu-util \
+    flex \
+    g++-12-multilib \
+    gcc-12-multilib \
+    genromfs \
+    gettext \
+    git \
+    git-lfs \
+    gnupg \
+    gperf \
+    jq \
+    less \
+    lsb-release \
+    libasound2-dev \
+    libasound2-plugins \
+    libc++-dev \
+    libc++abi-dev \
+    libc6-dev \
+    libdivsufsort-dev \
+    libncurses5 \
+    libprotobuf-dev \
+    libpulse-dev \
+    libusb-1.0-0-dev \
+    libuv1-dev \
+    libv4l-dev \
+    libx11-dev \
+    libxext-dev \
+    locales \
+    make \
+    mtools \
+    nasm \
+    net-tools \
+    ninja-build \
+    nodejs \
+    npm \
+    pkgconf \
+    protobuf-c-compiler \
+    protobuf-compiler \
+    python-is-python3 \
+    python3 \
+    python3-pip \
+    python3-venv \
+    qemu-efi-aarch64 \
+    qemu-system-arm \
+    qemu-system-misc \
+    qemu-utils \
+    rsync \
+    sudo \
+    u-boot-tools \
+    unzip \
+    wget \
+    xxd \
+    xz-utils \
+    yasm \
+    zip \
+  && locale-gen C.UTF-8 \
+  && git lfs install --system \
+  && rm -rf /var/lib/apt/lists/*
 
-# Pull in the tools we just built for openvela
-COPY --from=openvela-tools /tools/bloaty/ bloaty/
-ENV PATH="/tools/bloaty/bin:$PATH"
+# Own apt transaction: pulled into the main one, apt reports held broken
+# packages. libunwind-dev:i386 must not be used, it removes the amd64 dev
+# package and breaks every 64-bit link; install the runtime lib and add the
+# development symlinks instead.
+RUN apt-get update -qq \
+  && apt-get install -y -qq --no-install-recommends \
+    libunwind8:i386 \
+    linux-libc-dev:i386 \
+    zlib1g-dev:i386 \
+  && for l in libunwind libunwind-x86; do \
+       so=$(ls /usr/lib/i386-linux-gnu/$l.so.* 2>/dev/null | head -1); \
+       [ -n "$so" ] && ln -sf "$(basename "$so")" "/usr/lib/i386-linux-gnu/$l.so"; \
+     done \
+  && rm -rf /var/lib/apt/lists/*
 
-# Pull in the Rust toolchain including supported targets
-COPY --from=openvela-tools /tools/rust/ /tools/rust/
-ENV CARGO_HOME=/tools/rust/cargo
-ENV RUSTUP_HOME=/tools/rust/rustup
-ENV PATH="/tools/rust/cargo/bin:$PATH"
+# The vendored libc++ does not compile with Ubuntu 22.04's default GCC 11.
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 20 \
+  && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 20
 
-# Pull in the Zig v0.13.0 toolchain
-COPY --from=openvela-tools /tools/zig/ /tools/zig/
-ENV PATH="/tools/zig/0.13.0/files:$PATH"
+RUN python3 -m pip install \
+    coloredlogs \
+    construct \
+    cxxfilt \
+    jinja2 \
+    kconfiglib \
+    lark \
+    pexpect==4.8.0 \
+    pyelftools \
+    pyserial==3.5 \
+    pytest==6.2.5 \
+    pytest-json==0.4.0 \
+    pytest-ordering==0.6 \
+    pytest-repeat==0.9.1 \
+    stringcase
 
-# Pull in the ldc2 1.39.0 toolchain
-COPY --from=openvela-tools /tools/ldc2/ /tools/ldc2/
-ENV PATH="/tools/ldc2/ldc2-1.39.0-linux-x86_64/bin:$PATH"
+RUN python3 -m venv /opt/ntfc-venv \
+  && /opt/ntfc-venv/bin/pip install \
+    ntfc==0.0.1 \
+    pytest==7.4.4 \
+  && ln -s /opt/ntfc-venv/bin/ntfc /usr/local/bin/ntfc
 
-# Pull in the swift 6.0 toolchain
-# COPY --from=openvela-tools /tools/swift/ /tools/swift/
-# ENV PATH="/tools/swift/swift-6.0-DEVELOPMENT-SNAPSHOT-2024-08-22-a/usr/bin:$PATH"
+RUN curl -fsSL https://storage.googleapis.com/git-repo-downloads/repo \
+      -o /usr/local/bin/repo \
+  && chmod +x /usr/local/bin/repo
 
-# ARM clang toolchain
-COPY --from=openvela-toolchain-arm /tools/clang-arm-none-eabi/ clang-arm-none-eabi/
-# RUN cp /usr/bin/clang-extdef-mapping-10 clang-arm-none-eabi/bin/clang-extdef-mapping
-ENV PATH="/tools/clang-arm-none-eabi/bin:$PATH"
+COPY scripts/openvela-* /usr/local/bin/
 
-# ARM GCC toolchain
-COPY --from=openvela-toolchain-arm /tools/gcc-arm-none-eabi/ gcc-arm-none-eabi/
-ENV PATH="/tools/gcc-arm-none-eabi/bin:$PATH"
+RUN chmod a+x /usr/local/bin/openvela-*
 
-# ARM64 toolchain
-COPY --from=openvela-toolchain-arm64 /tools/gcc-aarch64-none-elf/ gcc-aarch64-none-elf/
-ENV PATH="/tools/gcc-aarch64-none-elf/bin:$PATH"
+RUN groupadd --gid "${OPENVELA_GID}" openvela \
+  && useradd --uid "${OPENVELA_UID}" --gid "${OPENVELA_GID}" \
+    --create-home --shell /bin/bash openvela \
+  && mkdir -p /workspace \
+  && chown openvela:openvela /workspace \
+  && echo "openvela ALL=(ALL) NOPASSWD:ALL" >/etc/sudoers.d/openvela \
+  && chmod 0440 /etc/sudoers.d/openvela
 
-# AVR32 toolchain
-COPY --from=openvela-toolchain-avr32 /tools/gcc-avr32-gnu/ gcc-avr32-gnu/
-ENV PATH="/tools/gcc-avr32-gnu/bin:$PATH"
+WORKDIR /workspace
 
-# MIPS toolchain
-COPY --from=openvela-toolchain-pinguino /tools/pinguino-compilers/p32/ pinguino-compilers/p32/
-ENV PATH="/tools/pinguino-compilers/p32/bin:$PATH"
+USER openvela
 
-# Renesas toolchain
-COPY --from=openvela-toolchain-renesas /tools/renesas-toolchain/rx-elf-gcc/ renesas-toolchain/rx-elf-gcc/
-ENV PATH="/tools/renesas-toolchain/rx-elf-gcc/bin:$PATH"
-
-# RISCV toolchain
-COPY --from=openvela-toolchain-riscv /tools/riscv-none-elf-gcc/ riscv-none-elf-gcc/
-ENV PATH="/tools/riscv-none-elf-gcc/bin:$PATH"
-
-# SPARC toolchain
-COPY --from=openvela-toolchain-sparc /tools/sparc-gaisler-elf-gcc/ sparc-gaisler-elf-gcc/
-ENV PATH="/tools/sparc-gaisler-elf-gcc/bin:$PATH"
-
-# WASI-enabled WebAssembly C/C++ toolchain
-COPY --from=openvela-toolchain-wasm /tools/wasi-sdk/ wasi-sdk/
-ENV WASI_SDK_PATH="/tools/wasi-sdk"
-ENV PATH="/tools/wamr:$PATH"
-
-# gn tool
-RUN mkdir -p /tools/gn
-COPY --from=openvela-tools /tools/gn/gn/out/gn /tools/gn
-ENV PATH="/tools/gn:$PATH"
-
-# ZAP tool and nodejs packet
-COPY --from=openvela-tools /tools/zap/ /tools/zap/
-COPY --from=openvela-tools /tools/zap_release/ /tools/zap_release/
-ENV ZAP_INSTALL_PATH=/tools/zap_release
-ENV ZAP_DEVELOPMENT_PATH=/tools/zap
-
-CMD [ "/bin/bash" ]
+CMD ["/bin/bash"]

--- a/.github/workflows/docker_linux/scripts/openvela-init
+++ b/.github/workflows/docker_linux/scripts/openvela-init
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+manifest_url="https://github.com/open-vela/manifests.git"
+branch="dev"
+manifest="openvela.xml"
+groups=""
+jobs="$(nproc)"
+depth_args=(--depth=1)
+sync_only=0
+
+usage() {
+  cat <<'EOF'
+Usage: openvela-init [options]
+
+Initialize and sync an OpenVela workspace using repo.
+
+Options:
+  --url <url>          Manifest repository URL.
+                       Default: https://github.com/open-vela/manifests.git
+  --branch <branch>   Manifest branch. Default: dev
+  --manifest <file>   Manifest file. Default: openvela.xml
+  --groups <groups>   Optional repo groups. Default: use manifest defaults.
+  --jobs <n>          Sync parallelism. Default: nproc
+  --no-depth          Do not pass --depth=1 to repo init.
+  --sync-only         Skip repo init and only run repo sync.
+  -h, --help          Show this help.
+
+Examples:
+  openvela-init
+  openvela-init --branch trunk --jobs 16
+  openvela-init --groups default,platform-linux,platform-linux-x86_64
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --url)
+      manifest_url="$2"
+      shift 2
+      ;;
+    --branch)
+      branch="$2"
+      shift 2
+      ;;
+    --manifest)
+      manifest="$2"
+      shift 2
+      ;;
+    --groups)
+      groups="$2"
+      shift 2
+      ;;
+    --jobs)
+      jobs="$2"
+      shift 2
+      ;;
+    --no-depth)
+      depth_args=()
+      shift
+      ;;
+    --sync-only)
+      sync_only=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "openvela-init: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+git lfs install >/dev/null
+
+if ! git config --global user.name >/dev/null; then
+  git config --global user.name "${GIT_USER_NAME:-OpenVela CI}"
+fi
+
+if ! git config --global user.email >/dev/null; then
+  git config --global user.email "${GIT_USER_EMAIL:-openvela-ci@example.invalid}"
+fi
+
+# Avoid repo init's interactive "Enable color display" prompt in fresh
+# containers. This is local UI configuration only; it does not affect checkout
+# authentication or remotes.
+if ! git config --global color.ui >/dev/null; then
+  git config --global color.ui false
+fi
+
+if [[ "${sync_only}" -eq 0 ]]; then
+  repo_init_args=(
+    repo init
+    -u "${manifest_url}"
+    -b "${branch}"
+    -m "${manifest}"
+    --git-lfs
+    "${depth_args[@]}"
+  )
+
+  if [[ -n "${groups}" ]]; then
+    repo_init_args+=(--group="${groups}")
+  fi
+
+  "${repo_init_args[@]}"
+fi
+
+repo sync -c -j"${jobs}"

--- a/.github/workflows/docker_linux/scripts/openvela-ntfc-setup
+++ b/.github/workflows/docker_linux/scripts/openvela-ntfc-setup
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+ntfc_dir="${NTFCDIR:-/workspace/ntfc}"
+repo_url="${OPENVELA_NTFC_TESTING_URL:-https://github.com/apache/nuttx-ntfc-testing.git}"
+branch="${OPENVELA_NTFC_TESTING_BRANCH:-release-0.0.1}"
+jobs="$(nproc)"
+
+usage() {
+  cat <<'EOF'
+Usage: openvela-ntfc-setup [options]
+
+Prepare the NTFC test case workspace used by NuttX/OpenVela runtime tests.
+
+Options:
+  --dir <dir>       NTFC workspace directory. Default: $NTFCDIR or /workspace/ntfc
+  --repo <url>      NTFC testing repository.
+                   Default: https://github.com/apache/nuttx-ntfc-testing.git
+  --branch <ref>    NTFC testing branch/tag. Default: release-0.0.1
+  --jobs <n>        Reserved for future parallel setup. Default: nproc
+  -h, --help        Show this help.
+
+The resulting layout matches Apache NuttX CI:
+  $NTFCDIR/external/nuttx-testing
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dir)
+      ntfc_dir="$2"
+      shift 2
+      ;;
+    --repo)
+      repo_url="$2"
+      shift 2
+      ;;
+    --branch)
+      branch="$2"
+      shift 2
+      ;;
+    --jobs)
+      jobs="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "openvela-ntfc-setup: unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! "${jobs}" =~ ^[0-9]+$ || "${jobs}" -lt 1 ]]; then
+  echo "openvela-ntfc-setup: --jobs must be a positive integer" >&2
+  exit 2
+fi
+
+if ! command -v ntfc >/dev/null 2>&1; then
+  echo "openvela-ntfc-setup: ntfc command not found" >&2
+  exit 1
+fi
+
+mkdir -p "${ntfc_dir}/external"
+
+testing_dir="${ntfc_dir}/external/nuttx-testing"
+if [[ -d "${testing_dir}/.git" ]]; then
+  git -C "${testing_dir}" fetch --depth=1 origin "${branch}"
+  git -C "${testing_dir}" checkout --detach FETCH_HEAD
+else
+  rm -rf "${testing_dir}"
+  git clone --depth=1 --branch "${branch}" "${repo_url}" "${testing_dir}"
+fi
+
+echo "NTFCDIR=${ntfc_dir}"
+echo "NTFC_TESTPATH=${testing_dir}"
+ntfc --help >/dev/null

--- a/.github/workflows/openvela-ci.yml
+++ b/.github/workflows/openvela-ci.yml
@@ -1,0 +1,129 @@
+name: OpenVela CI
+
+# Reusable OpenVela CI for any manifest repository (nuttx, apps, vendor
+# trees, ...). The caller repository only needs a thin workflow:
+#
+#   jobs:
+#     ci:
+#       uses: open-vela/public-actions/.github/workflows/openvela-ci.yml@dev
+#       with:
+#         repo-path: nuttx
+#
+# Each testlist in `testlists` becomes one job building through the
+# repository's tools/testbuild.sh with the vela build-system plugin.
+# Testlists, testbuild.sh and the plugin always come from the workspace
+# nuttx tree: the overlaid one when nuttx itself is under test, the
+# manifest checkout otherwise.
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Docker image containing OpenVela CI tools.
+        default: ghcr.io/open-vela/openvela-ci-linux:dev
+        required: false
+        type: string
+      manifest-branch:
+        description: Repo manifest branch.
+        default: dev
+        required: false
+        type: string
+      repo-path:
+        description: Manifest checkout path for the repository under test.
+        default: ""
+        required: false
+        type: string
+      testlists:
+        description: >-
+          JSON array of testlist names under tools/ci/testlist/ to build,
+          one matrix job each. The default is every list in the tree that
+          resolves to at least one buildable target -- 25 lists, 964
+          targets. Deliberately excluded: macos.dat and msys2.dat (other
+          hosts) and codechecker.dat (separate tooling). Excluded because
+          they resolve to zero buildable targets, every entry being
+          blacklisted upstream or the file holding blacklist lines only:
+          other, risc-v-02, risc-v-03, risc-v-05, xtensa-01, xtensa-02.
+          Recheck with: tools/testbuild.sh -p -N <list> | awk
+          '/^Skipping: /{s++;next} /^Configuration\/Tool: /{t++}
+          END{print t-s}'
+        default: >-
+          ["arm-01", "arm-02", "arm-03", "arm-04", "arm-05", "arm-06",
+           "arm-07", "arm-08", "arm-09", "arm-10", "arm-11", "arm-12",
+           "arm-13", "arm-14", "arm64-01", "risc-v-01", "risc-v-04",
+           "risc-v-06", "sim-01", "sim-02", "sim-03", "x86_64-01",
+           "vela-arm-01", "vela-arm64-01", "vela-x86_64-01"]
+        required: false
+        type: string
+      citest-testlist:
+        description: >-
+          Runtime-test (NTFC) testlist. Empty string disables the citest job.
+        default: tools/ci/testlist/vela-citest.dat
+        required: false
+        type: string
+      max-targets:
+        description: Maximum targets per testlist. Use 0 for all targets.
+        default: "0"
+        required: false
+        type: string
+      jobs:
+        description: Build parallelism.
+        default: "4"
+        required: false
+        type: string
+      ci-assets-repository:
+        description: Repository containing OpenVela CI helper assets.
+        default: open-vela/public-actions
+        required: false
+        type: string
+      ci-assets-ref:
+        description: Ref for ci-assets-repository.
+        default: dev
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        testlist: ${{ fromJSON(inputs.testlists) }}
+    name: ${{ matrix.testlist }}
+    uses: ./.github/workflows/openvela-repo-ci.yml
+    with:
+      image: ${{ inputs.image }}
+      manifest-branch: ${{ inputs.manifest-branch }}
+      repo-path: ${{ inputs.repo-path }}
+      testlist: tools/ci/testlist/${{ matrix.testlist }}.dat
+      max-targets: ${{ inputs.max-targets }}
+      jobs: ${{ inputs.jobs }}
+      artifact-name: openvela-ci-${{ matrix.testlist }}
+      job-name: build ${{ matrix.testlist }}
+      ci-assets-repository: ${{ inputs.ci-assets-repository }}
+      ci-assets-ref: ${{ inputs.ci-assets-ref }}
+
+  citest:
+    if: ${{ inputs.citest-testlist != '' }}
+    uses: ./.github/workflows/openvela-repo-ci.yml
+    with:
+      image: ${{ inputs.image }}
+      manifest-branch: ${{ inputs.manifest-branch }}
+      repo-path: ${{ inputs.repo-path }}
+      testlist: ${{ inputs.citest-testlist }}
+      max-targets: ${{ inputs.max-targets }}
+      jobs: ${{ inputs.jobs }}
+      run-runtime-tests: true
+      require-runtime-tests: true
+      artifact-name: openvela-ci-citest
+      job-name: NTFC runtime (citest)
+      # The manifest's vendored libc++ (a clang-only fork) shadows the
+      # upstream download+patch path in libs/libxx and cannot be compiled
+      # by the host GCC that sim builds use. Prune it so the citest build
+      # takes the same upstream libc++ path as Apache NuttX CI. Vendor
+      # targets keep the vendored copy (they build with prebuilt clang).
+      prune-workspace-paths: nuttx/libs/libxx/libcxx/libcxx
+      ci-assets-repository: ${{ inputs.ci-assets-repository }}
+      ci-assets-ref: ${{ inputs.ci-assets-ref }}

--- a/.github/workflows/openvela-repo-ci.yml
+++ b/.github/workflows/openvela-repo-ci.yml
@@ -1,0 +1,299 @@
+name: OpenVela Repo CI
+
+on:
+  workflow_call:
+    inputs:
+      image:
+        description: Docker image containing OpenVela CI tools.
+        default: ghcr.io/open-vela/openvela-ci-linux:dev
+        required: false
+        type: string
+      manifest-url:
+        description: Repo manifest URL.
+        default: https://github.com/open-vela/manifests.git
+        required: false
+        type: string
+      manifest-branch:
+        description: Repo manifest branch.
+        default: dev
+        required: false
+        type: string
+      manifest-file:
+        description: Repo manifest file.
+        default: openvela.xml
+        required: false
+        type: string
+      manifest-groups:
+        description: Optional repo manifest groups. Empty uses manifest defaults.
+        default: ""
+        required: false
+        type: string
+      testlist:
+        description: >-
+          Testlist under the nuttx tree, e.g. tools/ci/testlist/sim-01.dat.
+        default: tools/ci/testlist/sim-01.dat
+        required: false
+        type: string
+      max-targets:
+        description: Maximum number of testlist targets to build.
+        default: "1"
+        required: false
+        type: string
+      run-runtime-tests:
+        description: Run target run.sh scripts after successful builds.
+        default: false
+        required: false
+        type: boolean
+      require-runtime-tests:
+        description: Fail runtime-enabled jobs if a target has no executable run.sh.
+        default: false
+        required: false
+        type: boolean
+      ntfc-testing-url:
+        description: NTFC test case repository.
+        default: https://github.com/apache/nuttx-ntfc-testing.git
+        required: false
+        type: string
+      ntfc-testing-branch:
+        description: NTFC test case branch or tag.
+        default: release-0.0.1
+        required: false
+        type: string
+      jobs:
+        description: Parallelism for repo sync and build.
+        default: "4"
+        required: false
+        type: string
+      repo-path:
+        description: Manifest checkout path for the repository under test.
+        default: ""
+        required: false
+        type: string
+      artifact-name:
+        description: Uploaded artifact name.
+        default: openvela-ci-artifacts
+        required: false
+        type: string
+      ci-assets-repository:
+        description: Repository containing OpenVela CI testlists.
+        default: open-vela/public-actions
+        required: false
+        type: string
+      ci-assets-ref:
+        description: Ref for ci-assets-repository.
+        default: dev
+        required: false
+        type: string
+      job-name:
+        description: Display name for the job.
+        default: build
+        required: false
+        type: string
+      prune-workspace-paths:
+        description: >-
+          Space-separated workspace-relative paths removed after the overlay
+          and before the build, e.g. manifest checkouts that must not
+          shadow a repository's own build logic.
+        default: ""
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  openvela:
+    name: ${{ inputs.job-name }}
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ inputs.image }}
+      options: --user root
+    steps:
+      - name: Checkout change
+        uses: actions/checkout@v5
+        with:
+          path: change
+          fetch-depth: 0
+
+      - name: Checkout CI assets
+        uses: actions/checkout@v5
+        with:
+          repository: ${{ inputs.ci-assets-repository }}
+          ref: ${{ inputs.ci-assets-ref }}
+          path: ci-assets
+
+      - name: Initialize OpenVela workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mkdir -p "${GITHUB_WORKSPACE}/openvela"
+          cd "${GITHUB_WORKSPACE}/openvela"
+
+          init_args=(
+            --url "${{ inputs.manifest-url }}" \
+            --branch "${{ inputs.manifest-branch }}" \
+            --manifest "${{ inputs.manifest-file }}" \
+            --jobs "${{ inputs.jobs }}"
+          )
+
+          if [[ -n "${{ inputs.manifest-groups }}" ]]; then
+            init_args+=(--groups "${{ inputs.manifest-groups }}")
+          fi
+
+          openvela-init "${init_args[@]}"
+
+      - name: Resolve repository path
+        id: repo_path
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo_path="${{ inputs.repo-path }}"
+          if [[ -z "${repo_path}" ]]; then
+            repo_name="${GITHUB_REPOSITORY#*/}"
+            manifest="${GITHUB_WORKSPACE}/openvela/.repo/manifests/${{ inputs.manifest-file }}"
+
+            repo_path="$(python3 - "${manifest}" "${repo_name}" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          manifest_path, repo_name = sys.argv[1:3]
+          root = ET.parse(manifest_path).getroot()
+          matches = [
+              project.attrib["path"]
+              for project in root.findall("project")
+              if project.attrib.get("name") == repo_name
+          ]
+          if len(matches) != 1:
+              raise SystemExit(
+                  f"expected exactly one project named {repo_name!r}, found {len(matches)}"
+              )
+          print(matches[0])
+          PY
+          )"
+          fi
+
+          if [[ -z "${repo_path}" || "${repo_path}" == /* || "${repo_path}" == *".."* ]]; then
+            echo "Invalid repo path: ${repo_path}" >&2
+            exit 1
+          fi
+
+          echo "path=${repo_path}" >> "${GITHUB_OUTPUT}"
+          echo "OpenVela repository path: ${repo_path}"
+
+      - name: Report branch alignment
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo_path="${{ steps.repo_path.outputs.path }}"
+          manifest_dir="${GITHUB_WORKSPACE}/openvela/${repo_path}"
+          change_dir="${GITHUB_WORKSPACE}/change"
+          manifest_head="$(git -C "${manifest_dir}" rev-parse HEAD)"
+          change_head="$(git -C "${change_dir}" rev-parse HEAD)"
+
+          echo "Manifest branch: ${{ inputs.manifest-branch }}"
+          echo "Manifest ${repo_path} revision: ${manifest_head}"
+          echo "Change revision: ${change_head}"
+
+          if ! git -C "${change_dir}" merge-base --is-ancestor "${manifest_head}" HEAD; then
+            echo "::warning::The repository under test is not based on the manifest ${repo_path} revision. CI syncs all OpenVela repositories from manifest branch '${{ inputs.manifest-branch }}' and overlays only '${repo_path}'. Rebase the tested branch onto the same OpenVela branch selected by the manifest, normally 'dev' for contribution work or 'trunk' for stable-branch work."
+          fi
+
+      - name: Overlay repository under test
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          repo_path="${{ steps.repo_path.outputs.path }}"
+          source_dir="${GITHUB_WORKSPACE}/change/"
+          target_dir="${GITHUB_WORKSPACE}/openvela/${repo_path}"
+          manifest="${GITHUB_WORKSPACE}/openvela/.repo/manifests/${{ inputs.manifest-file }}"
+          exclude_file="${RUNNER_TEMP}/openvela-rsync-excludes.txt"
+
+          python3 - "${manifest}" "${repo_path}" > "${exclude_file}" <<'PY'
+          import sys
+          import xml.etree.ElementTree as ET
+
+          manifest_path, repo_path = sys.argv[1:3]
+          repo_prefix = repo_path.rstrip("/") + "/"
+
+          print("/.git")
+          for project in ET.parse(manifest_path).getroot().findall("project"):
+              path = project.attrib.get("path")
+              if path and path.startswith(repo_prefix):
+                  print("/" + path[len(repo_prefix):].rstrip("/") + "/***")
+          PY
+
+          mkdir -p "$(dirname "${target_dir}")"
+          mkdir -p "${target_dir}"
+          rsync -a --delete --exclude-from="${exclude_file}" "${source_dir}" "${target_dir}/"
+          git -C "${target_dir}" add -A
+
+      - name: Prune workspace paths
+        if: ${{ inputs.prune-workspace-paths != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          for p in ${{ inputs.prune-workspace-paths }}; do
+            if [[ "${p}" == /* || "${p}" == *".."* ]]; then
+              echo "Invalid prune path: ${p}" >&2
+              exit 1
+            fi
+            echo "Pruning ${p}"
+            rm -rf "${GITHUB_WORKSPACE}/openvela/${p}"
+          done
+
+      - name: Prepare NTFC
+        if: ${{ inputs.run-runtime-tests }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          ntfc_dir="${GITHUB_WORKSPACE}/ntfc"
+          openvela-ntfc-setup \
+            --dir "${ntfc_dir}" \
+            --repo "${{ inputs.ntfc-testing-url }}" \
+            --branch "${{ inputs.ntfc-testing-branch }}" \
+            --jobs "${{ inputs.jobs }}"
+
+          echo "NTFCDIR=${ntfc_dir}" >> "${GITHUB_ENV}"
+
+      - name: Run OpenVela CI build
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          testlist="${{ inputs.testlist }}"
+          workspace="${GITHUB_WORKSPACE}/openvela"
+
+          if [[ "${testlist}" == /* || "${testlist}" == *".."* ]]; then
+            echo "Invalid testlist path: ${testlist}" >&2
+            exit 1
+          fi
+
+          # Resolved from the workspace nuttx tree: the overlay when nuttx
+          # is under test, the manifest checkout otherwise.
+          adapter_args=(
+            --workspace "${workspace}"
+            --repo-path "nuttx"
+            --testlist "${workspace}/nuttx/${testlist}"
+            --max-targets "${{ inputs.max-targets }}"
+            --jobs "${{ inputs.jobs }}"
+          )
+          if [[ "${{ inputs.run-runtime-tests }}" == "true" ]]; then
+            adapter_args+=(--run-tests)
+          fi
+          if [[ "${{ inputs.require-runtime-tests }}" == "true" ]]; then
+            adapter_args+=(--require-run-script)
+          fi
+          bash "${GITHUB_WORKSPACE}/ci-assets/tools/openvela-testbuild-ci" "${adapter_args[@]}"
+      - name: Upload CI artifacts
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: openvela/ci-artifacts/**
+          if-no-files-found: warn

--- a/tools/openvela-testbuild-ci
+++ b/tools/openvela-testbuild-ci
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# tools/openvela-testbuild-ci
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# CI adapter around the repo-under-test's tools/testbuild.sh for the
+# OpenVela reusable workflow. Trims the list to --max-targets, runs
+# testbuild.sh with the vela build-system plugin, tees the log under
+# ci-artifacts/testbuild/ and writes a one-row summary.tsv.
+
+set -o pipefail
+
+usage() {
+  echo "USAGE: $0 --workspace <dir> --repo-path <rel> --testlist <file>"
+  echo "          [--max-targets <n>] [--jobs <n>] [--run-tests] [--require-run-script]"
+  exit 1
+}
+
+WORKSPACE=""
+REPO_PATH=""
+TESTLIST=""
+MAX_TARGETS=0
+JOBS=4
+RUN_TESTS=0
+REQUIRE_RUN=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --workspace) shift; WORKSPACE="$1" ;;
+    --repo-path) shift; REPO_PATH="$1" ;;
+    --testlist) shift; TESTLIST="$1" ;;
+    --max-targets) shift; MAX_TARGETS="$1" ;;
+    --jobs) shift; JOBS="$1" ;;
+    --run-tests) RUN_TESTS=1 ;;
+    --require-run-script) REQUIRE_RUN=1 ;;
+    *) echo "ERROR: unknown option: $1"; usage ;;
+  esac
+  shift
+done
+
+[ -n "$WORKSPACE" ] && [ -n "$REPO_PATH" ] && [ -n "$TESTLIST" ] || usage
+[ -r "$TESTLIST" ] || { echo "ERROR: testlist not readable: $TESTLIST"; exit 1; }
+
+repo_dir="$WORKSPACE/$REPO_PATH"
+testbuild="$repo_dir/tools/testbuild.sh"
+plugin="$repo_dir/tools/ci/buildsystems/vela.sh"
+[ -r "$testbuild" ] || { echo "ERROR: $testbuild not found"; exit 1; }
+[ -r "$plugin" ] || { echo "ERROR: $plugin not found"; exit 1; }
+
+artifacts="$WORKSPACE/ci-artifacts/testbuild"
+listname="$(basename "$TESTLIST" .dat)"
+mkdir -p "$artifacts/$listname"
+
+runlist="$TESTLIST"
+if [ "$MAX_TARGETS" -gt 0 ] 2>/dev/null; then
+  runlist="$artifacts/$listname/trimmed.dat"
+  awk -v n="$MAX_TARGETS" '
+    /^#/ || /^-/ || /^[Cc][Mm][Aa][Kk][Ee],/ || /^[[:space:]]*$/ { print; next }
+    count < n { print; count++ }
+  ' "$TESTLIST" > "$runlist"
+  echo "Trimmed to first $MAX_TARGETS target line(s); wildcards count as one line:"
+  grep -vE "^#|^[[:space:]]*$" "$runlist" || true
+fi
+
+args=(
+  -N
+  -e "-Wno-cpp -Werror"
+  -j "$JOBS"
+  -t "$WORKSPACE/nuttx"
+  -a "$WORKSPACE/apps"
+  --buildsystem "$plugin"
+)
+if [ "$RUN_TESTS" -eq 1 ]; then
+  args+=(-R)
+  export VELA_REQUIRE_RUN=$REQUIRE_RUN
+fi
+
+log="$artifacts/$listname/testbuild.log"
+export ARTIFACTDIR="$artifacts/$listname/buildartifacts"
+status=PASS
+if ! bash "$testbuild" "${args[@]}" "$runlist" 2>&1 | tee "$log"; then
+  status=FAIL
+fi
+
+printf 'status\ttestlist\tlog\n' > "$artifacts/summary.tsv"
+printf '%s\t%s\t%s\n' "$status" "$listname" \
+  "ci-artifacts/testbuild/$listname/testbuild.log" >> "$artifacts/summary.tsv"
+
+attempted=$(grep -c "^Configuration/Tool:" "$log" 2>/dev/null || true)
+skipped=$(grep -c "^Skipping:" "$log" 2>/dev/null || true)
+passed=$(grep -c "^  PASS:" "$log" 2>/dev/null || true)
+failed=$(grep -c "^  FAIL:" "$log" 2>/dev/null || true)
+
+if [ "${attempted:-0}" -eq 0 ]; then
+  echo "ERROR: testlist expanded to zero targets; refusing to report success" >&2
+  status=FAIL
+fi
+
+echo "===================================================================================="
+echo "openvela-testbuild-ci summary"
+echo "  testlist:  $listname"
+echo "  targets:   $attempted listed, $skipped blacklist-skipped"
+echo "  results:   $passed passed, $failed failed"
+echo "  status:    $status"
+echo "  full log:  ci-artifacts/testbuild/$listname/testbuild.log"
+echo "  per-target build.sh log: ci-artifacts/testbuild/$listname/buildartifacts/<board>/<config>/build.log"
+echo "===================================================================================="
+
+# Totals and failed targets go to the GitHub job summary; the plugin adds
+# one row per target.
+if [ -n "$GITHUB_STEP_SUMMARY" ]; then
+  {
+    echo
+    echo "### $listname: $passed passed, $failed failed" \
+         "($skipped blacklist-skipped of $attempted listed)"
+    if [ "${failed:-0}" -gt 0 ]; then
+      echo
+      echo "Failed targets:"
+      echo
+      grep "^  FAIL:" "$log" | sed 's/^  FAIL: /- `/; s/;.*/`/'
+    fi
+  } >> "$GITHUB_STEP_SUMMARY"
+fi
+
+if [ "${failed:-0}" -gt 0 ]; then
+  echo "::error title=$listname::$failed of $attempted targets failed to build"
+fi
+
+[ "$status" = PASS ]


### PR DESCRIPTION
1. ci: add testbuild-driven reusable OpenVela CI workflows
    
    openvela-ci.yml is the entry point a repository calls: it runs one job
    per testlist plus an NTFC runtime job.
    
    Each job calls openvela-repo-ci.yml, which builds a single testlist in
    the CI image: repo sync, overlay of the repository under test, then its
    tools/testbuild.sh with the OpenVela plugin.
    
    tools/openvela-testbuild-ci is the adapter that invokes testbuild.sh and
    reports the per-list verdict to the GitHub job summary.
    
2. docker: rebuild the CI image as a minimal OpenVela host image
    
    Install host packages only and take every toolchain from the manifest
    prebuilts, dropping the inherited Zig, GN, ZAP, Rust and LDC downloads.
    
    The 32-bit sim configs need i386 packages in their own apt transaction.
    libunwind-dev:i386 must not be used: it removes the amd64 dev package
    and breaks every 64-bit link. u-boot-tools supplies mkimage.
    
    Build on pull requests, publish on push to dev, tagging the image with
    the branch that produced it plus an immutable sha- tag.
